### PR TITLE
fix: Add missing currentChatSessionId state to chat-panel-v2

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -1053,6 +1053,7 @@ export function ChatPanelV2({
   const [currentBranchId, setCurrentBranchId] = useState<string | null>(null)
   const [toolExecutions, setToolExecutions] = useState<ToolExecution[]>([])
   const [elapsedTime, setElapsedTime] = useState(0)
+  const [currentChatSessionId, setCurrentChatSessionId] = useState<string | null>(null)
 
   // Load database ID from workspace if not provided
   // Try multiple methods for maximum accuracy


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the missing currentChatSessionId state to ChatPanelV2 to prevent undefined references and ensure the active chat session is tracked correctly. This fixes runtime errors when components expect a session ID.

<sup>Written for commit 9eefd330453de23a6883ac94551cae57a6cae861. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

