### PR TITLE
feat: Make branching and slash commands fully functional

### DIFF
--- a/components/ui/chat-session-selector.tsx
+++ b/components/ui/chat-session-selector.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { useState, useEffect, useCallback } from "react"
-import { MessageSquare, Plus, MoreHorizontal, Pencil, Trash2, Check, X, GitBranch } from "lucide-react"
+import { MessageSquare, Plus, MoreHorizontal, Pencil, Trash2, Check, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -344,14 +344,6 @@ export function ChatSessionSelector({
             </div>
           )}
 
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            className="text-xs text-muted-foreground justify-center"
-            disabled
-          >
-            <GitBranch className="h-3 w-3 mr-1" />
-            Branch from message (coming soon)
-          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
     </TooltipProvider>

--- a/components/ui/conversation-branch.tsx
+++ b/components/ui/conversation-branch.tsx
@@ -74,7 +74,7 @@ interface CreateBranchDialogProps {
   onCreateBranch: (name: string, description?: string) => void
 }
 
-function CreateBranchDialog({
+export function CreateBranchDialog({
   open,
   onOpenChange,
   messagePreview,


### PR DESCRIPTION
- Add branch button to user messages for creating conversation branches
- Open branch creation dialog when clicking branch button on any message
- Auto-switch to new branch after creation (local state update)
- Remove "branching coming soon" notice from chat session selector
- Update /memory command to open full memory context dialog
- Export CreateBranchDialog for reuse
- Clean up unused GitBranch import from chat-session-selector

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables branching from any message and makes the /memory command open a real memory dialog. After creating a branch, the chat auto-switches to it.

- **New Features**
  - Branch button on user messages opens a CreateBranchDialog with a message preview.
  - Auto-switch to the new branch after creation (local state update).
  - /memory opens a Memory Context dialog with session and message info.

- **Refactors**
  - Exported CreateBranchDialog and integrated it into ChatPanelV2.
  - Removed the “branching coming soon” notice and cleaned an unused GitBranch import.

<sup>Written for commit f9817407e481b137ac5296f02e213a49ec796207. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

