### PR TITLE
fix: Search & Replace functionality and modal z-index issues

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5254,7 +5254,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
 
         {/* Memory Context Dialog */}
         <Dialog open={showMemoryDialog} onOpenChange={setShowMemoryDialog}>
-          <DialogContent className="sm:max-w-lg">
+          <DialogContent className="sm:max-w-lg z-[100]">
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 <Database className="h-5 w-5" />


### PR DESCRIPTION
- Fix executeReplace using wrong API call (was file.id, now projectId, filePath)
- Add proper progress indicator during replace operation
- Add replaceProgress state for tracking replace progress
- Dispatch files-changed event after replace to refresh file explorer
- Add z-[100] to search dialog to display above mobile bottom tab (z-50)
- Add z-[100] to memory dialog for same reason
- Improve warning message in replace tab with better wording
- Handle partial failures during replace with error reporting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Search & Replace by calling the correct storage API and adds a clear progress indicator. Also resolves modal z-index issues so dialogs display above the mobile bottom tab.

- **Bug Fixes**
  - Use updateFile(projectId, filePath) for replace operations.
  - Show a toast and block replace when no project is selected.
  - Dispatch a files-changed event after replace to refresh the file explorer.
  - Handle partial failures and report errors in the toast.
  - Set z-[100] on Search and Memory dialogs to render above the mobile bottom tab.

- **New Features**
  - Add replaceProgress state and UI with percent and progress bar.
  - Improve warning text in the Replace tab and hide it during active replace.

<sup>Written for commit 56b8437e9cabadd6cd97c09a53d4673890a54d52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

