### PR TITLE
feat: Add Smartsupp live chat support to website

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -106,6 +106,21 @@ export default function RootLayout({
             `,
           }}
         />
+        {/* Smartsupp Live Chat */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              var _smartsupp = _smartsupp || {};
+              _smartsupp.key = '126786a363f7baa554ae5643bc620390b84f1696';
+              window.smartsupp||(function(d) {
+                var s,c,o=smartsupp=function(){ o._.push(arguments)};o._=[];
+                s=d.getElementsByTagName('script')[0];c=d.createElement('script');
+                c.type='text/javascript';c.charset='utf-8';c.async=true;
+                c.src='https://www.smartsuppchat.com/loader.js?';s.parentNode.insertBefore(c,s);
+              })(document);
+            `,
+          }}
+        />
       </head>
       <body className="dark:bg-gray-900 dark:text-white font-sans">
         <ServiceWorkerProvider />


### PR DESCRIPTION
Integrate Smartsupp live chat widget in the root layout for real-time customer support across all pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Smartsupp live chat across the site by injecting its loader script in the root layout. This enables real-time support on every page without blocking page load.

- **New Features**
  - Site-wide chat via Smartsupp loader script in <head>.
  - Async, non-blocking initialization.
  - Configured with the project’s Smartsupp site key.

<sup>Written for commit fda966fff5ccad6d1ab5646bf15120428191cb65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

