### PR TITLE
feat: Switch from Smartsupp to Tawk.to for live chat

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -106,18 +106,19 @@ export default function RootLayout({
             `,
           }}
         />
-        {/* Smartsupp Live Chat */}
+        {/* Tawk.to Live Chat */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
-              var _smartsupp = _smartsupp || {};
-              _smartsupp.key = '126786a363f7baa554ae5643bc620390b84f1696';
-              window.smartsupp||(function(d) {
-                var s,c,o=smartsupp=function(){ o._.push(arguments)};o._=[];
-                s=d.getElementsByTagName('script')[0];c=d.createElement('script');
-                c.type='text/javascript';c.charset='utf-8';c.async=true;
-                c.src='https://www.smartsuppchat.com/loader.js?';s.parentNode.insertBefore(c,s);
-              })(document);
+              var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
+              (function(){
+                var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
+                s1.async=true;
+                s1.src='https://embed.tawk.to/696f56620938061981966d61/1jfdeist0';
+                s1.charset='UTF-8';
+                s1.setAttribute('crossorigin','*');
+                s0.parentNode.insertBefore(s1,s0);
+              })();
             `,
           }}
         />


### PR DESCRIPTION
Replace Smartsupp live chat widget with Tawk.to for customer support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the live chat provider from Smartsupp to Tawk.to by updating the embed script in app/layout.tsx. This enables Tawk.to chat for customer support with no other UI or behavior changes.

<sup>Written for commit 512d102aa6c9084137f41291729f47d31a4aa32c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

