### PR TITLE
fix: Hide Tawk.to widget on /docs page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -117,7 +117,8 @@ export default function RootLayout({
               function shouldHideTawkWidget() {
                 var isWorkspaceWithProject = window.location.pathname === '/workspace' && window.location.search.includes('projectId');
                 var isSupportPage = window.location.pathname === '/support';
-                return isWorkspaceWithProject || isSupportPage;
+                var isDocsPage = window.location.pathname === '/docs';
+                return isWorkspaceWithProject || isSupportPage || isDocsPage;
               }
 
               // Function to update widget visibility


### PR DESCRIPTION
Since the docs page now has its own AI chat widget, hide the Tawk.to widget there as well to avoid duplicate chat interfaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Tawk.to widget on /docs to prevent duplicate chat since the docs page has its own widget. Adds an isDocsPage check to shouldHideTawkWidget in app/layout.tsx.

<sup>Written for commit d37a41cbd372c4f77c05aeb9dc2b7a68f3bd0fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

