### PR TITLE
Claude/find fix bug mklk8yrw6bjaexko 4t oj q

### DIFF
--- a/app/api/support-chat/route.ts
+++ b/app/api/support-chat/route.ts
@@ -380,16 +380,27 @@ Remember: You represent PiPilot. Be professional, helpful, and make users feel s
         return msg
       }
       // Handle multimodal messages (text + images)
+      const transformedContent = msg.content.map((part: ContentPart) => {
+        if (part.type === 'text') {
+          return { type: 'text' as const, text: part.text }
+        } else if (part.type === 'image') {
+          // Ensure image is properly formatted for AI SDK
+          // AI SDK accepts: URL, data URI, base64 string, Uint8Array, Buffer
+          const imageData = part.image
+          return { type: 'image' as const, image: imageData }
+        }
+        return part
+      })
+
+      // Log image count for debugging
+      const imageCount = transformedContent.filter(p => p.type === 'image').length
+      if (imageCount > 0) {
+        console.log(`Processing message with ${imageCount} image(s)`)
+      }
+
       return {
         role: msg.role,
-        content: msg.content.map((part: ContentPart) => {
-          if (part.type === 'text') {
-            return { type: 'text' as const, text: part.text }
-          } else if (part.type === 'image') {
-            return { type: 'image' as const, image: part.image }
-          }
-          return part
-        })
+        content: transformedContent
       }
     })
 

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -72,27 +72,25 @@ interface Attachment {
   preview?: string
 }
 
-// Serialize messages for localStorage (exclude image data)
-function serializeMessagesForStorage(messages: ChatMessage[]): ChatMessage[] {
-  return messages.map(msg => {
+// Prepare messages for AI context - strip images from OLD messages, keep current message intact
+// This prevents sending old images as context while allowing current images to be analyzed
+function prepareMessagesForAI(messages: ChatMessage[], currentMessage: ChatMessage): ChatMessage[] {
+  const previousMessages = messages.map(msg => {
     if (typeof msg.content === 'string') return msg
-    // Filter out image parts for storage, keep text only
+    // For old messages, only keep text content (no images)
     const textParts = msg.content.filter((p): p is TextContent => p.type === 'text')
     if (textParts.length === 0) {
-      return { role: msg.role, content: '[Image/Screenshot shared]' }
+      return { role: msg.role, content: '[User shared an image/screenshot]' }
     }
-    // If there were images, note it in the content
+    // If there were images, note that images were shared but don't include them
     const hadImages = msg.content.some(p => p.type === 'image')
-    if (hadImages) {
-      return {
-        role: msg.role,
-        content: textParts.length === 1
-          ? `${textParts[0].text}\n\n[Image/Screenshot shared]`
-          : textParts.map(p => p.text).join('\n') + '\n\n[Image/Screenshot shared]'
-      }
+    if (hadImages && textParts.length === 1) {
+      return { role: msg.role, content: `${textParts[0].text}\n\n[Image/Screenshot was shared]` }
     }
     return { role: msg.role, content: textParts.length === 1 ? textParts[0].text : textParts }
   })
+  // Add current message with full content (including images)
+  return [...previousMessages, currentMessage]
 }
 
 // FAQ Data organized by category
@@ -315,14 +313,32 @@ export default function SupportPage() {
     }
   }, [])
 
-  // Save chat history to localStorage when messages change
+  // Save chat history to localStorage when messages change (includes images for display)
   useEffect(() => {
     if (messages.length > 0) {
       try {
-        const toStore = serializeMessagesForStorage(messages)
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore))
+        // Save full messages including images for display purposes
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(messages))
       } catch (error) {
-        console.error('Failed to save chat history:', error)
+        // If storage fails (quota exceeded due to images), try saving without images
+        console.error('Failed to save chat history with images, trying without:', error)
+        try {
+          const textOnlyMessages = messages.map(msg => {
+            if (typeof msg.content === 'string') return msg
+            const textParts = msg.content.filter((p): p is TextContent => p.type === 'text')
+            const hadImages = msg.content.some(p => p.type === 'image')
+            if (textParts.length === 0) {
+              return { role: msg.role, content: '[Image/Screenshot was shared]' }
+            }
+            if (hadImages) {
+              return { role: msg.role, content: textParts[0].text + '\n\n[Image/Screenshot was shared]' }
+            }
+            return { role: msg.role, content: textParts.length === 1 ? textParts[0].text : textParts }
+          })
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(textOnlyMessages))
+        } catch (e) {
+          console.error('Failed to save chat history:', e)
+        }
       }
     }
   }, [messages])
@@ -579,11 +595,14 @@ export default function SupportPage() {
     }, 1200)
 
     try {
+      // Prepare messages for AI - strip images from old messages, keep current message images
+      const messagesForAI = prepareMessagesForAI(messages, userMessage)
+
       const response = await fetch('/api/support-chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          messages: [...messages, userMessage]
+          messages: messagesForAI
         })
       })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persisted chat history on Docs and Support pages and improved multimodal message handling for more reliable conversations. Added a “Searching documentation...” status indicator to show when tools are running.

- **New Features**
  - Chat history persists in localStorage across reloads and sessions.
  - Saves images for display; falls back to text-only if storage quota is exceeded.
  - Shows “Searching documentation...” after 1.2s when tools are in use; cleared on first streamed content.
  - Clear Chat now also clears localStorage.

- **Bug Fixes**
  - Old messages sent to the backend exclude images to reduce request size; current message images are kept.
  - Normalized image parts in the chat API and added image count logging.
  - Stream handling cleans up timers and status to prevent stale indicators.

<sup>Written for commit 3a511c46cee87340005a53a7ff28f9066ecec366. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

