### PR TITLE
fix: Expand sidebar width + hide Tawk.to on agent-cloud page

### DIFF
--- a/app/agent-cloud/page.tsx
+++ b/app/agent-cloud/page.tsx
@@ -1079,7 +1079,7 @@ export default function AgentCloudPage() {
       <div className="flex-1 flex overflow-hidden relative">
         {/* Mobile sidebar */}
         <div className={`
-          fixed inset-y-0 left-0 w-80 max-w-[85vw] bg-zinc-950 border-r border-zinc-800/50 z-50
+          fixed inset-y-0 left-0 w-[340px] max-w-[90vw] bg-zinc-950 border-r border-zinc-800/50 z-50
           transform transition-transform duration-300 ease-out md:hidden
           ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}
           pt-16
@@ -1089,7 +1089,7 @@ export default function AgentCloudPage() {
 
         {/* Desktop sidebar */}
         {sidebarOpen && (
-          <div className="w-80 border-r border-zinc-800/50 flex-col bg-zinc-950 hidden md:flex">
+          <div className="w-[340px] min-w-[340px] border-r border-zinc-800/50 flex-col bg-zinc-950 hidden md:flex">
             <SidebarContent />
           </div>
         )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -118,7 +118,8 @@ export default function RootLayout({
                 var isWorkspaceWithProject = window.location.pathname === '/workspace' && window.location.search.includes('projectId');
                 var isSupportPage = window.location.pathname === '/support';
                 var isDocsPage = window.location.pathname === '/docs';
-                return isWorkspaceWithProject || isSupportPage || isDocsPage;
+                var isAgentCloudPage = window.location.pathname === '/agent-cloud';
+                return isWorkspaceWithProject || isSupportPage || isDocsPage || isAgentCloudPage;
               }
 
               // Function to update widget visibility


### PR DESCRIPTION
- Increase sidebar width from 320px to 340px to prevent chat input overflow
- Add min-width to prevent sidebar shrinking
- Hide Tawk.to chat widget on /agent-cloud page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the Agent Cloud sidebar to 340px with a min-width to prevent chat input overflow and shrinking. Also hide the Tawk.to widget on /agent-cloud to avoid UI overlap.

<sup>Written for commit 5f94b97da138558814f46f14b491b2fdee25103d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

