### PR TITLE
fix: Wrap useSearchParams in Suspense boundary for Next.js 15

### DIFF
--- a/app/agent-cloud/layout.tsx
+++ b/app/agent-cloud/layout.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, createContext, useContext, useCallback } from "react"
+import { useState, useEffect, createContext, useContext, useCallback, Suspense } from "react"
 import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -117,7 +117,8 @@ export function useAgentCloud() {
   return context
 }
 
-export default function AgentCloudLayout({
+// Inner component that uses useSearchParams
+function AgentCloudLayoutInner({
   children,
 }: {
   children: React.ReactNode
@@ -647,5 +648,22 @@ export default function AgentCloudLayout({
         </div>
       </div>
     </AgentCloudContext.Provider>
+  )
+}
+
+// Wrapper with Suspense for useSearchParams
+export default function AgentCloudLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <Suspense fallback={
+      <div className="h-screen flex items-center justify-center bg-zinc-950">
+        <div className="animate-spin h-8 w-8 border-2 border-orange-500 border-t-transparent rounded-full" />
+      </div>
+    }>
+      <AgentCloudLayoutInner>{children}</AgentCloudLayoutInner>
+    </Suspense>
   )
 }

--- a/app/agent-cloud/session/page.tsx
+++ b/app/agent-cloud/session/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useRef, useEffect, useCallback, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import {
@@ -14,10 +14,10 @@ import {
   Sparkles,
   ArrowUp,
 } from "lucide-react"
-import { useAgentCloud, type TerminalLine, type Session } from "../layout"
+import { useAgentCloud, type TerminalLine } from "../layout"
 import { Response } from "@/components/ai-elements/response"
 
-export default function SessionPage() {
+function SessionPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const sessionId = searchParams.get('id')
@@ -368,5 +368,18 @@ User Request: ${currentPrompt}`
         </div>
       )}
     </>
+  )
+}
+
+// Wrapper with Suspense for useSearchParams
+export default function SessionPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+      </div>
+    }>
+      <SessionPageInner />
+    </Suspense>
   )
 }


### PR DESCRIPTION
- Wrap layout component with Suspense for useSearchParams
- Wrap session page component with Suspense for useSearchParams
- Add loading fallback spinners during suspense

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap components that use useSearchParams in Suspense to align with Next.js 15 and prevent render/hydration errors. Adds simple loading spinners while search params resolve.

- **Bug Fixes**
  - Wrapped app/agent-cloud/layout.tsx with Suspense and a full-screen spinner; moved logic into AgentCloudLayoutInner.
  - Wrapped app/agent-cloud/session/page.tsx with Suspense and an inline spinner; moved logic into SessionPageInner.

<sup>Written for commit 4d1692b236fb09c26edc1e40acc617211b94fe45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

