### PR TITLE
feat: Add Playwright MCP for browser automation in Agent Cloud

### DIFF
--- a/app/agent-cloud/layout.tsx
+++ b/app/agent-cloud/layout.tsx
@@ -382,11 +382,11 @@ function AgentCloudLayoutInner({
           { type: 'system', content: `Reconnected to existing sandbox`, timestamp: new Date() },
           { type: 'system', content: `Repository: ${selectedRepo.full_name} (${selectedBranch})`, timestamp: new Date() },
           { type: 'system', content: `Model: ${modelInfo?.name || data.model}`, timestamp: new Date() },
-          { type: 'system', content: `MCP Tools: Tavily Search, GitHub`, timestamp: new Date() },
+          { type: 'system', content: `MCP Tools: Tavily Search, Playwright, GitHub`, timestamp: new Date() },
         ] : repoCloned ? [
           { type: 'system', content: `Cloned ${selectedRepo.full_name} (${selectedBranch})`, timestamp: new Date() },
           { type: 'system', content: `Model: ${modelInfo?.name || data.model}`, timestamp: new Date() },
-          { type: 'system', content: `MCP Tools: Tavily Search, GitHub`, timestamp: new Date() },
+          { type: 'system', content: `MCP Tools: Tavily Search, Playwright, GitHub`, timestamp: new Date() },
         ] : [
           { type: 'system', content: `Failed to clone ${selectedRepo.full_name}`, timestamp: new Date() },
         ]

--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -554,8 +554,8 @@ async function handleCreate(
     console.warn(`[Agent Cloud] Failed to install Claude Code CLI:`, e)
   }
 
-  // Setup MCP configuration with HTTP-based servers (Tavily for web search, GitHub for repo operations)
-  console.log(`[Agent Cloud] Setting up MCP tools (Tavily, GitHub, Filesystem)...`)
+  // Setup MCP configuration with HTTP-based servers (Tavily for web search, GitHub for repo operations, Playwright for browser automation)
+  console.log(`[Agent Cloud] Setting up MCP tools (Tavily, Playwright, GitHub, Filesystem)...`)
   try {
     // Create .claude directory for MCP config
     await sandbox.commands.run('mkdir -p /home/user/.claude', { timeoutMs: 5000 })
@@ -567,6 +567,11 @@ async function handleCreate(
       tavily: {
         type: "http",
         url: "https://mcp.tavily.com/mcp/?tavilyApiKey=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"
+      },
+      // Playwright MCP server for browser automation
+      playwright: {
+        command: "npx",
+        args: ["@playwright/mcp@latest"]
       },
       // Filesystem MCP server for local file operations
       filesystem: {
@@ -711,7 +716,7 @@ async function handleCreate(
     reconnected: false,
     messageCount: 0,
     mcpEnabled: true,
-    mcpTools: githubToken ? ['tavily', 'github', 'filesystem'] : ['tavily', 'filesystem'],
+    mcpTools: githubToken ? ['tavily', 'playwright', 'github', 'filesystem'] : ['tavily', 'playwright', 'filesystem'],
     message: repoCloned
       ? `Sandbox created with ${config?.repo?.full_name} cloned (MCP enabled)`
       : 'Sandbox created with Vercel AI Gateway (MCP enabled)',

--- a/e2b-agent-cloud.Dockerfile
+++ b/e2b-agent-cloud.Dockerfile
@@ -54,9 +54,9 @@ RUN useradd -m -s /bin/bash user
 RUN mkdir -p /home/user/.npm /home/user/.cache /home/user/project /app /home/user/.claude \
     && chown -R user:user /home/user /app
 
-# Pre-configure Tavily MCP HTTP server (API key embedded for web search capabilities)
+# Pre-configure MCP servers (Tavily for web search, Playwright for browser automation, Filesystem for local files)
 # This creates the base MCP config that will be extended at runtime with GitHub MCP
-RUN echo '{"mcpServers":{"tavily":{"type":"http","url":"https://mcp.tavily.com/mcp/?tavilyApiKey=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"},"filesystem":{"command":"npx","args":["-y","@anthropic/mcp-server-filesystem","/home/user/project"]}}}' > /home/user/.claude/mcp.json \
+RUN echo '{"mcpServers":{"tavily":{"type":"http","url":"https://mcp.tavily.com/mcp/?tavilyApiKey=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"},"playwright":{"command":"npx","args":["@playwright/mcp@latest"]},"filesystem":{"command":"npx","args":["-y","@anthropic/mcp-server-filesystem","/home/user/project"]}}}' > /home/user/.claude/mcp.json \
     && chown user:user /home/user/.claude/mcp.json
 
 # Set up Playwright in /app directory (required by Playwright)


### PR DESCRIPTION
Add Playwright MCP server to the E2B agent cloud template:
- Pre-configure Playwright MCP in Dockerfile mcp.json
- Add playwright to mcpServers in API route
- Update UI to show Playwright in MCP tools list

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Playwright MCP to Agent Cloud to enable browser automation in sandboxes. Playwright is preconfigured and surfaced in both server config and UI.

- **New Features**
  - Pre-configure Playwright MCP in ~/.claude/mcp.json via Dockerfile.
  - Register Playwright in mcpServers and include it in mcpTools (with or without GitHub).
  - Show Playwright in the MCP tools list in the UI.

<sup>Written for commit 9f59b07ab3721faee69cec807cb1b6075947fdf1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

