### PR TITLE
fix: Add --verbose flag required for stream-json with print mode

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -267,8 +267,9 @@ IMPORTANT GIT WORKFLOW INSTRUCTIONS:
 
         // Use --output-format stream-json for real-time streaming with newline-delimited JSON
         // stdbuf -oL forces line-buffered output so each JSON line is flushed immediately
+        // --verbose is required when using stream-json with -p (print mode)
         // --append-system-prompt adds git workflow instructions while keeping Claude's default capabilities
-        const command = `cd ${workDir} && stdbuf -oL -eL bash -c "echo '${base64Prompt}' | base64 -d | claude -p --dangerously-skip-permissions --output-format stream-json --append-system-prompt \\"$(echo '${base64SystemPrompt}' | base64 -d)\\"" 2>&1`
+        const command = `cd ${workDir} && stdbuf -oL -eL bash -c "echo '${base64Prompt}' | base64 -d | claude -p --verbose --dangerously-skip-permissions --output-format stream-json --append-system-prompt \\"$(echo '${base64SystemPrompt}' | base64 -d)\\"" 2>&1`
 
         let fullOutput = ''
         let jsonBuffer = ''


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix stream-json output with -p (print mode) by adding the required --verbose flag to the Claude CLI in the agent-cloud API route. Prevents stuck or missing newline-delimited JSON events during real-time streaming.

<sup>Written for commit e761bf6b64b5e95e72ec5db8ba1b57e5c199a9cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

