### PR TITLE
fix: Remove non-existent npm packages from Dockerfile

### DIFF
--- a/e2b-agent-cloud.Dockerfile
+++ b/e2b-agent-cloud.Dockerfile
@@ -61,8 +61,8 @@ RUN npm install -g pnpm@9
 # Install Claude Code CLI globally
 RUN npm install -g @anthropic-ai/claude-code
 
-# Install Playwright and MCP servers globally so they're available to the user
-RUN npm install -g @anthropic-ai/mcp-server-filesystem @playwright/mcp playwright
+# Install Playwright globally (MCP servers will be run via npx)
+RUN npm install -g playwright
 
 # Create a user with proper setup (matching E2B conventions)
 RUN useradd -m -s /bin/bash user


### PR DESCRIPTION
@anthropic-ai/mcp-server-filesystem doesn't exist on npm. MCP servers are run via npx at runtime, so no need to pre-install them. Only install playwright globally for browser automation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed @anthropic-ai/mcp-server-filesystem and @playwright/mcp from the Dockerfile and kept only playwright. This avoids build failures (filesystem server isn’t on npm) and reduces image size since MCP servers run via npx at runtime.

<sup>Written for commit 546461856e706eb75932abb830b3a5f600382f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

