### PR TITLE
fix: Remove filesystem MCP - Claude Code has built-in file access

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -594,12 +594,8 @@ async function handleCreate(
       playwright: {
         command: "npx",
         args: ["@playwright/mcp@latest"]
-      },
-      // Filesystem MCP server for local file operations
-      filesystem: {
-        command: "npx",
-        args: ["-y", "@anthropic/mcp-server-filesystem", PROJECT_DIR]
       }
+      // Note: Claude Code has built-in filesystem access, no need for filesystem MCP
     }
 
     // Add GitHub MCP if token is available (for GitHub operations)
@@ -747,7 +743,7 @@ async function handleCreate(
     reconnected: false,
     messageCount: 0,
     mcpEnabled: true,
-    mcpTools: githubToken ? ['tavily', 'playwright', 'github', 'filesystem'] : ['tavily', 'playwright', 'filesystem'],
+    mcpTools: githubToken ? ['tavily', 'playwright', 'github'] : ['tavily', 'playwright'],
     workingBranch: createdWorkingBranch, // The branch created for this session (e.g., pipilot-agent/fix-login-bug-a1b2)
     message: repoCloned
       ? `Sandbox created with ${config?.repo?.full_name} cloned (MCP enabled)`

--- a/e2b-agent-cloud.Dockerfile
+++ b/e2b-agent-cloud.Dockerfile
@@ -82,9 +82,6 @@ RUN claude mcp add --transport http tavily "https://mcp.tavily.com/mcp/?tavilyAp
 # Playwright for browser automation
 RUN claude mcp add playwright npx @playwright/mcp@latest
 
-# Filesystem for local file operations
-RUN claude mcp add filesystem npx -y @anthropic-ai/mcp-server-filesystem /home/user/project
-
 # Install Playwright browsers as user (Chromium only to save space)
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/user/.cache/ms-playwright
 RUN npx playwright install chromium


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the filesystem MCP; Claude Code already has built-in file access. This simplifies setup and avoids redundant tooling.

- **Refactors**
  - Stop registering the filesystem MCP in route.ts and remove it from mcpTools.
  - Delete the filesystem MCP setup command from e2b-agent-cloud.Dockerfile.

<sup>Written for commit 2990214556d6093723ddabf966383baef8114a35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

