### PR TITLE
refactor: Add all MCP servers dynamically at runtime

### DIFF
--- a/e2b-agent-cloud.Dockerfile
+++ b/e2b-agent-cloud.Dockerfile
@@ -71,16 +71,12 @@ RUN useradd -m -s /bin/bash user
 RUN mkdir -p /home/user/.npm /home/user/.cache /home/user/project /home/user/.claude /home/user/.cache/ms-playwright \
     && chown -R user:user /home/user
 
-# Switch to user for Claude CLI config and Playwright browser installation
+# Switch to user for Playwright browser installation
 USER user
 WORKDIR /home/user
 
-# Add MCP servers using Claude Code CLI
-# Tavily for web search (HTTP MCP)
-RUN claude mcp add --transport http tavily "https://mcp.tavily.com/mcp/?tavilyApiKey=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"
-
-# Playwright for browser automation
-RUN claude mcp add playwright npx @playwright/mcp@latest
+# MCP servers are added dynamically at runtime via the API
+# This ensures proper configuration with user-specific tokens (GitHub, etc.)
 
 # Install Playwright browsers as user (Chromium only to save space)
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/user/.cache/ms-playwright


### PR DESCRIPTION
Instead of pre-configuring MCPs in Dockerfile (which doesn't work), add all MCPs dynamically when sandbox starts using 'claude mcp add':

- Tavily: claude mcp add --transport http tavily <url>
- Playwright: claude mcp add playwright npx @playwright/mcp@latest
- GitHub: claude mcp add-json github <config with auth header>

This matches how GitHub MCP was working (dynamically added) and ensures all MCPs are properly registered and accessible to the AI.

Removed MCP setup from Dockerfile since it's now done at runtime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dynamically register Tavily, Playwright, and GitHub MCP servers at sandbox startup using Claude CLI, replacing Dockerfile setup. This fixes unreliable MCP configuration and allows GitHub to use per-user tokens.

- **Refactors**
  - Move MCP setup from Dockerfile to runtime in app/api/agent-cloud/route.ts using `claude mcp add` and `add-json`.
  - Add Tavily (HTTP) and Playwright; add GitHub only when a token is present.
  - Remove manual mcp.json writing; add servers via CLI and log success/warnings.

<sup>Written for commit edfa69f4b03473324c8583c79d485a04d6a36e33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

