### PR TITLE
fix: Use pipilot-agent template instead of base for E2B sandboxes

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -539,8 +539,8 @@ async function handleCreate(
     envs.GITHUB_TOKEN = githubToken
   }
 
-  // Use our custom template or fall back to base
-  const template = config?.template || 'base'
+  // Use our custom E2B template (pipilot-agent) which has Claude Code + Playwright pre-installed
+  const template = config?.template || 'pipilot-agent'
   const selectedModel = config?.model || 'sonnet'
 
   console.log(`[Agent Cloud] Creating new sandbox with template: ${template}`)


### PR DESCRIPTION
The custom E2B template has Claude Code CLI and Playwright pre-installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default E2B sandbox template to pipilot-agent, which bundles Claude Code CLI and Playwright, so sandboxes start ready to use without extra installs. Custom templates via config.template still override the default.

<sup>Written for commit a28648fe19a4943ba3556307878701bd6e950993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

