### PR TITLE
fix: Fix first prompt issue and MCP reconfiguration on reconnect

### DIFF
--- a/app/agent-cloud/session/page.tsx
+++ b/app/agent-cloud/session/page.tsx
@@ -212,28 +212,8 @@ User Request: ${currentPrompt}`
         enhancedPrompt = githubContext
       }
 
-      // Check sandbox status first via a quick fetch to detect 404
-      const checkResponse = await fetch(`/api/agent-cloud?sandboxId=${encodeURIComponent(sandboxIdToUse)}&prompt=${encodeURIComponent('ping')}`, {
-        method: 'GET',
-      })
-
-      // If sandbox not found/expired, recreate it
-      if (checkResponse.status === 404) {
-        console.log('Sandbox expired, recreating...')
-        const newSandboxId = await recreateSandbox()
-        if (newSandboxId) {
-          // Retry with the new sandbox
-          setIsLoading(false)
-          setIsStreaming(false)
-          runPrompt(currentPrompt, newSandboxId)
-          return
-        } else {
-          setIsLoading(false)
-          setIsStreaming(false)
-          return
-        }
-      }
-
+      // Connect to the streaming endpoint
+      // EventSource handles errors and we have sandbox recreation logic in onerror
       const eventSource = new EventSource(
         `/api/agent-cloud?sandboxId=${encodeURIComponent(sandboxIdToUse)}&prompt=${encodeURIComponent(enhancedPrompt)}`
       )


### PR DESCRIPTION
- Removed the "ping" check that was accidentally running Claude Code with "ping" prompt
- This fixes the issue where first prompt didn't work and needed to be sent twice
- Added MCP gateway reconfiguration when reconnecting to existing sandboxes
- Fresh MCP tokens are obtained and gateway is re-added on reconnection
- Added MCP list verification after adding gateway

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the first prompt failing due to an accidental "ping" request, and reconfigures the MCP gateway on sandbox reconnects to use fresh tokens. First prompts now run immediately, and tool connections stay valid after reconnects.

- **Bug Fixes**
  - Removed the "ping" pre-check that sent a bogus prompt; the initial prompt now streams right away.
  - Connected directly to the streaming endpoint; sandbox recreation is handled in EventSource onerror.

- **New Features**
  - On reconnect, remove and re-add the MCP gateway with a fresh token for existing sandboxes (including E2B).
  - After adding, list MCP servers to verify configuration and log the result.

<sup>Written for commit 1a5d40bdaca2f733c163e5e7ab61d531af3aa855. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

