### PR TITLE
Claude/fix cloning sandbox reuse np dt2

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -639,21 +639,7 @@ async function handleCreate(
   const sandboxId = sandbox.sandboxId
   let repoCloned = false
 
-  // Install Claude Code CLI in the sandbox
-  console.log(`[Agent Cloud] Installing Claude Code CLI...`)
-  try {
-    const installResult = await sandbox.commands.run(
-      'npm install -g @anthropic-ai/claude-code',
-      { timeoutMs: 120000 }
-    )
-    if (installResult.exitCode !== 0) {
-      console.warn(`[Agent Cloud] Claude Code install warning:`, installResult.stderr)
-    } else {
-      console.log(`[Agent Cloud] Claude Code CLI installed successfully`)
-    }
-  } catch (e) {
-    console.warn(`[Agent Cloud] Failed to install Claude Code CLI:`, e)
-  }
+  // Note: Claude Code CLI is pre-installed in the pipilot-agent template
 
   // Setup MCP configuration by writing mcp.json file directly
   // This is the working approach that was used before


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stream-json parsing by adding --verbose to the Claude CLI print mode. Removes the redundant CLI install because the pipilot-agent template already includes it, reducing sandbox startup time and improving reuse.

- **Bug Fixes**
  - Add --verbose when using claude -p with --output-format stream-json to ensure structured output.
  - Remove npm global install step; rely on pre-installed CLI in the pipilot-agent template.

<sup>Written for commit 0c78b9485710ce816fc561bb608cdc76fb4c4f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

