### PR TITLE
Refactor conversation handling to use single prompt string

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -299,8 +299,15 @@ if (historyFileArg) {
   }
 }
 
-const messages = conversationHistory.map(msg => ({ role: msg.role, content: msg.content }));
-messages.push({ role: 'user', content: promptArg });
+let fullPrompt = '';
+if (conversationHistory.length > 0) {
+  const context = conversationHistory
+    .map(msg => \`\${msg.role === 'user' ? 'Human' : 'Assistant'}: \${msg.content}\`)
+    .join('\\n\\n');
+  fullPrompt = \`Previous conversation:\\n\${context}\\n\\nCurrent request: \${promptArg}\`;
+} else {
+  fullPrompt = promptArg;
+}
 
 console.log(JSON.stringify({ type: 'start', timestamp: Date.now() }));
 
@@ -310,10 +317,10 @@ process.on('SIGINT', () => abortController.abort());
 
 try {
   for await (const message of query({
-    messages,
-    systemPrompt: systemPromptArg || undefined,
-    abortController,
+    prompt: fullPrompt,
     options: {
+      systemPrompt: systemPromptArg || undefined,
+      abortController,
       maxTurns: 20
     }
   })) {


### PR DESCRIPTION
## Summary
Refactored the conversation history handling in both the agent cloud API route and Claude SDK stream script to use a single formatted prompt string instead of a messages array. This change simplifies the API contract and improves context management by explicitly formatting conversation history as a readable text format.

## Key Changes
- **Conversation format**: Changed from passing a `messages` array to passing a single `prompt` string that includes previous conversation context
- **Context formatting**: Conversation history is now formatted as "Human: ... \n\n Assistant: ..." text blocks, making the context more readable to the model
- **API parameter restructuring**: Moved `systemPrompt` and `abortController` into the `options` object for cleaner API organization
- **Applied to both files**: Updated both `app/api/agent-cloud/route.ts` and `scripts/claude-sdk-stream.mjs` consistently

## Implementation Details
- When conversation history exists, it's formatted with clear "Human"/"Assistant" labels and joined with double newlines for readability
- The formatted history is prefixed with "Previous conversation:" and the current request is appended as "Current request:"
- When no history exists, the prompt is used as-is
- This approach maintains full conversation context while using a simpler single-string interface

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored conversation handling to use a single formatted prompt string and corrected SDK query() parameters, fixing stream failures and simplifying context passing.

- **Refactors**
  - Replace messages array with a prompt that includes history labeled as “Human”/“Assistant”, prefixed with “Previous conversation” and “Current request”.
  - Move systemPrompt and abortController into options.
  - Applied in app/api/agent-cloud/route.ts and scripts/claude-sdk-stream.mjs.

- **Bug Fixes**
  - Use prompt at the top level and systemPrompt/abortController under options in query(), resolving the async iterator TypeError.

<sup>Written for commit 72fc957f2c060276947fe26d07684e166a16d1f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

