### PR TITLE
fix: improve streaming UI, filter install noise, remove turn limit

### DIFF
--- a/app/agent-cloud/session/page.tsx
+++ b/app/agent-cloud/session/page.tsx
@@ -340,25 +340,36 @@ User Request: ${currentPrompt}`
             console.log('[Agent Cloud] Tool used:', data.name, data.input)
             const toolName = data.name || 'Unknown'
             const input = data.input || {}
-            let toolDescription = `Using ${toolName}`
+            let toolDescription = ''
 
             // Create user-friendly descriptions for common tools
-            if (toolName === 'Write' && input?.file_path) {
-              toolDescription = `Creating ${input.file_path.split('/').pop()}`
+            // Prefer the AI-provided description when available
+            if (toolName === 'Bash') {
+              if (input?.description) {
+                toolDescription = input.description
+              } else if (input?.command) {
+                toolDescription = `$ ${input.command.substring(0, 80)}${input.command.length > 80 ? '...' : ''}`
+              } else {
+                toolDescription = 'Running command'
+              }
+            } else if (toolName === 'Write' && input?.file_path) {
+              toolDescription = `Creating ${input.file_path}`
             } else if (toolName === 'Edit' && input?.file_path) {
-              toolDescription = `Editing ${input.file_path.split('/').pop()}`
+              toolDescription = `Editing ${input.file_path}`
             } else if (toolName === 'Read' && input?.file_path) {
-              toolDescription = `Reading ${input.file_path.split('/').pop()}`
-            } else if (toolName === 'Bash' && input?.command) {
-              toolDescription = `Running: ${input.command.substring(0, 60)}${input.command.length > 60 ? '...' : ''}`
+              toolDescription = `Reading ${input.file_path}`
             } else if (toolName === 'Glob' && input?.pattern) {
-              toolDescription = `Searching: ${input.pattern}`
+              toolDescription = `Finding files: ${input.pattern}`
             } else if (toolName === 'Grep' && input?.pattern) {
-              toolDescription = `Grep: ${input.pattern}`
+              toolDescription = `Searching for: ${input.pattern}`
             } else if (toolName === 'WebSearch' && input?.query) {
-              toolDescription = `Searching web: ${input.query.substring(0, 40)}${input.query.length > 40 ? '...' : ''}`
+              toolDescription = `Searching: ${input.query.substring(0, 60)}${input.query.length > 60 ? '...' : ''}`
             } else if (toolName === 'WebFetch' && input?.url) {
-              toolDescription = `Fetching: ${input.url}`
+              toolDescription = `Fetching: ${input.url.substring(0, 60)}${input.url.length > 60 ? '...' : ''}`
+            } else if (toolName === 'Task' && input?.description) {
+              toolDescription = input.description
+            } else {
+              toolDescription = `Using ${toolName}`
             }
 
             setSessions(prev => prev.map(s =>

--- a/scripts/claude-sdk-stream.mjs
+++ b/scripts/claude-sdk-stream.mjs
@@ -57,7 +57,6 @@ try {
     options: {
       systemPrompt: systemPromptArg || undefined,
       abortController,
-      maxTurns: 20,
       includePartialMessages: true
     }
   })) {


### PR DESCRIPTION
- Use AI-provided tool descriptions (e.g. "Check contents of directory") instead of raw commands for Bash tools
- Show full file paths for Read/Write/Edit tools
- Show Task description for subagent launches
- Filter out pnpm install output from being streamed to the frontend by tracking when the SDK script actually starts
- Remove maxTurns: 20 limit to allow unlimited agent turns

https://claude.ai/code/session_01LL7v76TQfNNPSwj3JSvTq1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Agent Cloud streaming with clearer tool activity and full file paths, filters pnpm install noise before the SDK starts, and removes the turn limit for uninterrupted sessions.

- **New Features**
  - Use tool-provided descriptions for Bash; fallback to trimmed command or “Running command”.
  - Show full file paths for Read, Write, and Edit.
  - Display Task descriptions for subagent launches.
  - Allow unlimited turns by removing maxTurns.

- **Bug Fixes**
  - Gate non-JSON stdout until the first “start” event to filter pnpm install output.
  - Clearer labels: Glob → “Finding files”, Grep → “Searching for”, WebSearch/WebFetch with trimmed text/URL.

<sup>Written for commit 161691b1df2c1318e31f6845bd5ad0028248d9bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

