### PR TITLE
feat: integrate E2B MCP gateway with Tavily for Agent SDK

### DIFF
--- a/scripts/claude-sdk-stream.mjs
+++ b/scripts/claude-sdk-stream.mjs
@@ -40,6 +40,16 @@ if (conversationHistory.length > 0) {
   fullPrompt = promptArg;
 }
 
+// Configure MCP servers from environment variables
+const mcpServers = {};
+if (process.env.MCP_GATEWAY_URL && process.env.MCP_GATEWAY_TOKEN) {
+  mcpServers['e2b-mcp'] = {
+    type: 'http',
+    url: process.env.MCP_GATEWAY_URL,
+    headers: { 'Authorization': `Bearer ${process.env.MCP_GATEWAY_TOKEN}` }
+  };
+}
+
 // Send start event
 console.log(JSON.stringify({ type: 'start', timestamp: Date.now() }));
 
@@ -57,7 +67,8 @@ try {
     options: {
       systemPrompt: systemPromptArg || undefined,
       abortController,
-      includePartialMessages: true
+      includePartialMessages: true,
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {})
     }
   })) {
     // Handle SDK message types


### PR DESCRIPTION
- Use E2B's built-in mcp option in Sandbox.create() with Tavily API key
- Get MCP gateway URL/token via sandbox.getMcpUrl()/getMcpToken()
- Pass gateway credentials as env vars (MCP_GATEWAY_URL, MCP_GATEWAY_TOKEN)
- Configure mcpServers in Agent SDK query options as HTTP type
- Remove old mcp.json file-writing approach
- Store MCP gateway credentials in sandbox entry for session reuse

https://claude.ai/code/session_01LL7v76TQfNNPSwj3JSvTq1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates E2B’s MCP gateway for Tavily into the Agent SDK and replaces the old file-based MCP setup. Sessions now auto-provision HTTP MCP credentials and pass them to the SDK via env vars.

- **New Features**
  - Provision Tavily MCP via Sandbox.create(mcp.tavily).
  - Fetch gateway URL/token and inject as MCP_GATEWAY_URL/TOKEN.
  - Attach mcpServers (HTTP) to Agent SDK queries when available.

- **Refactors**
  - Remove .claude/mcp.json and legacy MCP server setup.
  - Persist gateway credentials on the sandbox entry for reuse.
  - Set mcpEnabled based on gateway presence; tools list now ['tavily'].

<sup>Written for commit 95d1657e76fc7e4e25e345b4c7dccb7cdb0c385e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

