### PR TITLE
fix: resolve SWC parser error in tool_result content mapping

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -370,15 +370,22 @@ try {
       if (Array.isArray(content)) {
         for (const block of content) {
           if (block.type === 'tool_result') {
-            const resultContent = Array.isArray(block.content)
-              ? block.content.map((c: any) => c.type === 'text' ? c.text : `[${c.type}]`).join('\\n')
-              : typeof block.content === 'string'
-                ? block.content
-                : JSON.stringify(block.content);
+            let resultContent = '';
+            if (Array.isArray(block.content)) {
+              const parts = block.content.map((c: any) => {
+                if (c.type === 'text') return c.text;
+                return '[' + c.type + ']';
+              });
+              resultContent = parts.join('\n');
+            } else if (typeof block.content === 'string') {
+              resultContent = block.content;
+            } else {
+              resultContent = JSON.stringify(block.content);
+            }
             console.log(JSON.stringify({
               type: 'tool_result',
               tool_use_id: block.tool_use_id,
-              result: resultContent?.substring(0, 2000) || '',
+              result: (resultContent || '').substring(0, 2000),
               timestamp: Date.now()
             }));
           }


### PR DESCRIPTION
Break complex nested ternary with template literal into simpler if/else blocks to avoid SWC syntax parsing issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SWC parsing errors in tool_result content mapping by replacing a complex nested ternary and template literal with clear if/else blocks. Prevents build issues and ensures consistent parsing and logging of tool_result results.

<sup>Written for commit 303d7b0bb0ba6a59b2c3c4d5626d28d1122c23de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

