### PR TITLE
fix: escape newline in inline script template literal

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -376,7 +376,7 @@ try {
                 if (c.type === 'text') return c.text;
                 return '[' + c.type + ']';
               });
-              resultContent = parts.join('\n');
+              resultContent = parts.join('\\n');
             } else if (typeof block.content === 'string') {
               resultContent = block.content;
             } else {


### PR DESCRIPTION
The '\n' inside the template literal was being interpreted as an actual newline, producing an unterminated string in the generated .mjs file. Use '\\n' to output a literal \n in the script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes newline characters in the inline script to output literal \n, preventing unterminated strings in the generated .mjs file. Replaces parts.join('\n') with parts.join('\\n') when constructing resultContent.

<sup>Written for commit 2bd8af5d60102ebd1bd585b244f0c406b4153e85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

