### PR TITLE
fix: use pipilot-swe-bot as git username to match GitHub account

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -287,7 +287,7 @@ export async function GET(request: NextRequest) {
         const gitWorkflowPrompt = `
 IMPORTANT GIT WORKFLOW INSTRUCTIONS:
 - You are working on branch: ${workingBranch}
-- BEFORE committing, ALWAYS configure git user: git config user.name "PiPilot" && git config user.email "hello@pipilot.dev"
+- BEFORE committing, ALWAYS configure git user: git config user.name "pipilot-swe-bot" && git config user.email "hello@pipilot.dev"
 - Do NOT use git config user.name "Claude" or user.email "noreply@anthropic.com"
 - After making code changes, ALWAYS commit them with a clear message
 - After committing, push to the remote: git push -u origin ${workingBranch}
@@ -1061,7 +1061,7 @@ async function handleCreate(
 
         // Configure git user
         await sandbox.commands.run(
-          `cd ${PROJECT_DIR} && git config user.email "hello@pipilot.dev" && git config user.name "PiPilot Agent"`,
+          `cd ${PROJECT_DIR} && git config user.email "hello@pipilot.dev" && git config user.name "pipilot-swe-bot"`,
           { timeoutMs: 5000 }
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set git user.name to pipilot-swe-bot to match the GitHub bot account, ensuring commits are attributed correctly. Updated both the workflow prompt and the sandbox git config command to use pipilot-swe-bot with hello@pipilot.dev.

<sup>Written for commit d28ff864adf210b4224803dc6acdc45624dea9f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

