### PR TITLE
feat: add image support to new page and swap default model to devstral

### DIFF
--- a/app/agent-cloud/layout.tsx
+++ b/app/agent-cloud/layout.tsx
@@ -78,6 +78,7 @@ export interface Session {
   }
   messageCount?: number
   pendingPrompt?: string // Initial prompt to auto-send when session page loads
+  pendingImages?: Array<{ data: string; type: string; name: string }> // Images to attach when auto-sending
 }
 
 export interface Repository {
@@ -93,9 +94,9 @@ export interface Repository {
 
 // Available models
 export const MODELS = [
-  { id: 'sonnet', name: 'Default', provider: 'xAI', description: 'Grok Code Fast 1' },
+  { id: 'sonnet', name: 'Default', provider: 'Mistral', description: 'Devstral Small 2' },
   { id: 'opus', name: 'GLM 4.7', provider: 'ZAI', description: 'High quality responses' },
-  { id: 'haiku', name: 'Devstral', provider: 'Mistral', description: 'Quick tasks' },
+  { id: 'haiku', name: 'Grok', provider: 'xAI', description: 'Grok Code Fast 1' },
 ] as const
 
 // Context for sharing state across pages
@@ -118,7 +119,7 @@ interface AgentCloudContextType {
   isLoadingRepos: boolean
   isLoadingBranches: boolean
   loadBranches: (repoFullName: string) => Promise<void>
-  createSession: (initialPrompt: string) => Promise<Session | null>
+  createSession: (initialPrompt: string, images?: Array<{ data: string; type: string; name: string }>) => Promise<Session | null>
   terminateSession: (sessionId: string) => Promise<void>
   deleteSession: (sessionId: string) => void
   isCreating: boolean
@@ -343,7 +344,7 @@ function AgentCloudLayoutInner({
   }, [])
 
   // Create session
-  const createSession = async (initialPrompt: string): Promise<Session | null> => {
+  const createSession = async (initialPrompt: string, images?: Array<{ data: string; type: string; name: string }>): Promise<Session | null> => {
     if (!selectedRepo) {
       toast.error('Please select a repository first')
       return null
@@ -402,6 +403,7 @@ function AgentCloudLayoutInner({
         stats: { additions: 0, deletions: 0 },
         messageCount: data.messageCount || 0,
         pendingPrompt: initialPrompt, // Store the initial prompt to auto-send
+        pendingImages: images && images.length > 0 ? images : undefined, // Store images to attach when auto-sending
         lines: reconnected ? [
           { type: 'system', content: `Reconnected to existing sandbox`, timestamp: new Date() },
           { type: 'system', content: `Repository: ${selectedRepo.full_name} (${selectedBranch})`, timestamp: new Date() },

--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -39,9 +39,9 @@ const AI_GATEWAY_BASE_URL = 'https://ai-gateway.vercel.sh'
 
 // Available models through Vercel AI Gateway
 const AVAILABLE_MODELS = {
-  sonnet: 'xai/grok-code-fast-1',      // Fast code generation
+  sonnet: 'mistral/devstral-small-2',   // Default - fast code generation
   opus: 'zai/glm-4.7',                  // High quality
-  haiku: 'mistral/devstral-small-2',   // Quick tasks
+  haiku: 'xai/grok-code-fast-1',        // Quick tasks
 } as const
 
 // Store active sandboxes with user association


### PR DESCRIPTION
- Add image attachment (Paperclip) and paste support to new session page
- Pass pending images from new page to session page via pendingImages state
- Add overrideImages parameter to runPrompt for pending image handling
- Swap models: devstral-small-2 is now default, grok moves to haiku slot

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added image attachments and paste support on the New Session page, with images carried into the Session and auto-sent with the first prompt. Switched the default model to Devstral Small 2; Grok now lives in the haiku slot.

- **New Features**
  - Attach images via paperclip or paste on the New Session page, with previews and remove.
  - Images persist to the Session via pendingImages and upload to the sandbox on send.
  - Image-only requests are supported; submit is disabled only when both prompt and images are empty.

- **Migration**
  - createSession(initialPrompt, images?) now accepts optional images.
  - runPrompt(overridePrompt?, overrideSandboxId?, overrideImages?) now accepts optional images.

<sup>Written for commit 134e7c3ff49ab1e73372b9cb47e64ffc61d002e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

