### PR TITLE
Claude/enhance message display u zwo l

### DIFF
--- a/app/agent-cloud/session/page.tsx
+++ b/app/agent-cloud/session/page.tsx
@@ -483,11 +483,11 @@ User Request: ${currentPrompt}`
             // Build prompt with conversation history context for continuity
             const historyLines = activeSession.lines
               .filter(l => l.type === 'input' || l.type === 'output')
-              .slice(-10) // Last 10 exchanges for context (avoid token limits)
+              .slice(-12) // Last 6 pairs (12 messages) for context
             let contextPrompt = currentPrompt
             if (historyLines.length > 0) {
               const historyContext = historyLines
-                .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.substring(0, 500)}`)
+                .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.length > 800 ? l.content.substring(0, 800) + '...[truncated]' : l.content}`)
                 .join('\n\n')
               contextPrompt = `[Conversation History - This is a resumed session after reconnection]\n${historyContext}\n\n[Current Request]\n${currentPrompt}`
             }
@@ -752,11 +752,11 @@ User Request: ${currentPrompt}`
               if (newSandboxId) {
                 const historyLines = activeSession.lines
                   .filter(l => l.type === 'input' || l.type === 'output')
-                  .slice(-10)
+                  .slice(-12)
                 let contextPrompt = currentPrompt
                 if (historyLines.length > 0) {
                   const historyContext = historyLines
-                    .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.substring(0, 500)}`)
+                    .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.length > 800 ? l.content.substring(0, 800) + '...[truncated]' : l.content}`)
                     .join('\n\n')
                   contextPrompt = `[Conversation History - This is a resumed session after reconnection]\n${historyContext}\n\n[Current Request]\n${currentPrompt}`
                 }
@@ -838,11 +838,11 @@ User Request: ${currentPrompt}`
           if (newSandboxId) {
             const historyLines = activeSession.lines
               .filter(l => l.type === 'input' || l.type === 'output')
-              .slice(-10)
+              .slice(-12)
             let contextPrompt = currentPrompt
             if (historyLines.length > 0) {
               const historyContext = historyLines
-                .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.substring(0, 500)}`)
+                .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.length > 800 ? l.content.substring(0, 800) + '...[truncated]' : l.content}`)
                 .join('\n\n')
               contextPrompt = `[Conversation History - This is a resumed session after reconnection]\n${historyContext}\n\n[Current Request]\n${currentPrompt}`
             }
@@ -889,11 +889,11 @@ User Request: ${currentPrompt}`
         if (newSandboxId) {
           const historyLines = activeSession.lines
             .filter(l => l.type === 'input' || l.type === 'output')
-            .slice(-10)
+            .slice(-12)
           let contextPrompt = currentPrompt
           if (historyLines.length > 0) {
             const historyContext = historyLines
-              .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.substring(0, 500)}`)
+              .map(l => `${l.type === 'input' ? 'User' : 'Assistant'}: ${l.content.length > 800 ? l.content.substring(0, 800) + '...[truncated]' : l.content}`)
               .join('\n\n')
             contextPrompt = `[Conversation History - This is a resumed session after reconnection]\n${historyContext}\n\n[Current Request]\n${currentPrompt}`
           }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized conversation history to the last 6 pairs (12 messages) with 800‑char truncation, and removed duplicate server-side history wrapping. This prevents repeated context on session recreation and reduces token usage.

- **Bug Fixes**
  - Detect embedded history markers and skip file-based history to avoid duplication on recreated sessions.
  - Apply the 6‑pair limit and 800‑char truncation across all retry/recreation paths.
  - Server now encodes only the raw prompt; history is handled by the client/script.

- **New Features**
  - Auto-provision an empty conversation history file on sandbox creation for immediate read/write.

<sup>Written for commit 33f8a2f2572f8811b0b451afac57ac98dec57f64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

