### PR TITLE
fix: use natural letter-spacing for OpenDyslexic font readability

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,16 +8,16 @@
   font-display: swap;
 }
 
-/* OpenDyslexic font with normal spacing */
+/* OpenDyslexic font with natural readable spacing */
 * {
   font-family: 'OpenDyslexic', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }
 
-/* Override OpenDyslexic's default spacing to match normal fonts */
-body, p, div, span, h1, h2, h3, h4, h5, h6, button, input, textarea, select {
-  letter-spacing: -0.02em !important;
-  word-spacing: normal !important;
-  font-feature-settings: normal !important;
+/* Natural spacing optimized for OpenDyslexic readability */
+body, p, div, span, h1, h2, h3, h4, h5, h6, button, input, textarea, select, a, label, li {
+  letter-spacing: normal !important;
+  word-spacing: 0.05em !important;
+  line-height: 1.5 !important;
 }
 
 :root {
@@ -140,7 +140,7 @@ body, p, div, span, h1, h2, h3, h4, h5, h6, button, input, textarea, select {
   --ring: #3b82f6;
 
   /* Font definitions for dark theme */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-sans: 'OpenDyslexic', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', Monaco, 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
 
   /* VS Code-style sidebar colors for dark theme */
@@ -155,7 +155,7 @@ body, p, div, span, h1, h2, h3, h4, h5, h6, button, input, textarea, select {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-poppins), 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font-sans);
 }
 
 @layer base {
@@ -164,7 +164,7 @@ body {
   }
 
   body {
-    font-family: var(--font-poppins), 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(--font-sans);
   }
 
   code {

--- a/public/chat-test.html
+++ b/public/chat-test.html
@@ -24,8 +24,9 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
             padding: 20px;
-            letter-spacing: -0.02em !important;
-            word-spacing: normal !important;
+            letter-spacing: normal;
+            word-spacing: 0.05em;
+            line-height: 1.5;
         }
 
         .container {

--- a/public/model-test.html
+++ b/public/model-test.html
@@ -24,8 +24,9 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
             padding: 20px;
-            letter-spacing: -0.02em !important;
-            word-spacing: normal !important;
+            letter-spacing: normal;
+            word-spacing: 0.05em;
+            line-height: 1.5;
         }
         
         .container {

--- a/public/tool-test.html
+++ b/public/tool-test.html
@@ -25,8 +25,9 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
             padding: 20px;
-            letter-spacing: -0.02em !important;
-            word-spacing: normal !important;
+            letter-spacing: normal;
+            word-spacing: 0.05em;
+            line-height: 1.5;
         }
 
         .container {


### PR DESCRIPTION
- Changed letter-spacing from -0.02em to normal (was squishing text)
- Added line-height: 1.5 for better vertical readability
- Fixed dark theme to include OpenDyslexic in font stack
- Removed Poppins fallback to use consistent OpenDyslexic font
- Updated test HTML files with matching font styling

https://claude.ai/code/session_01CBJNi6WboPyPP4CMYJTJSR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves readability with OpenDyslexic by using natural letter spacing, slight word spacing, and a 1.5 line-height. Ensures the dark theme consistently uses OpenDyslexic instead of Poppins.

- **Bug Fixes**
  - Set letter-spacing to normal, word-spacing to 0.05em, and line-height to 1.5 for OpenDyslexic.
  - Updated dark theme font stack to include OpenDyslexic and removed Poppins fallback; body now uses --font-sans.
  - Synced chat/model/tool test pages with the new spacing settings.

<sup>Written for commit 46c3618fc46a317bfe07071984f1723c21778679. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

