### PR TITLE
feat: switch app font from Josefin Slab to Marmelad

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,8 @@
 @import "tailwindcss";
 
-/* Josefin Slab font applied globally */
+/* Marmelad font applied globally */
 * {
-  font-family: "Josefin Slab", serif;
-  font-optical-sizing: auto;
+  font-family: "Marmelad", sans-serif;
 }
 
 :root {
@@ -29,7 +28,7 @@
   --radius: 0.5rem;
 
   /* Font definitions */
-  --font-sans: "Josefin Slab", serif;
+  --font-sans: "Marmelad", sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', Monaco, 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
 
   /* VS Code-style sidebar colors */
@@ -61,7 +60,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --font-sans: "Josefin Slab", serif;
+  --font-sans: "Marmelad", sans-serif;
   --font-mono: var(--font-mono);
 }
 
@@ -90,7 +89,7 @@
     --ring: #3b82f6;
 
     /* Font definitions for dark theme */
-    --font-sans: "Josefin Slab", serif;
+    --font-sans: "Marmelad", sans-serif;
     --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', Monaco, 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
 
     /* VS Code-style sidebar colors for dark theme */
@@ -126,7 +125,7 @@
   --ring: #3b82f6;
 
   /* Font definitions for dark theme */
-  --font-sans: "Josefin Slab", serif;
+  --font-sans: "Marmelad", sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'SF Mono', Monaco, 'Inconsolata', 'Roboto Mono', 'Source Code Pro', monospace;
 
   /* VS Code-style sidebar colors for dark theme */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -92,10 +92,10 @@ export default function RootLayout({
         <meta name="theme-color" content="#6366f1" />
         <link rel="apple-touch-icon" sizes="152x152" href="/icons/icon-152x152.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180x180.png" />
-        {/* Google Fonts - Josefin Slab & Special Elite */}
+        {/* Google Fonts - Marmelad, Josefin Slab & Special Elite */}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Josefin+Slab:ital,wght@0,100..700;1,100..700&family=Special+Elite&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Josefin+Slab:ital,wght@0,100..700;1,100..700&family=Marmelad&family=Special+Elite&display=swap" rel="stylesheet" />
         {/* OneSignal SDK */}
         <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
         <script


### PR DESCRIPTION
- Added Marmelad font to Google Fonts imports
- Replaced Josefin Slab with Marmelad as the default app font
- Homepage still uses Special Elite for futuristic styling

https://claude.ai/code/session_01CBJNi6WboPyPP4CMYJTJSR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the app’s default font from Josefin Slab (serif) to Marmelad (sans-serif) for better readability, addressing the “fix dyslexic font styling” Linear issue. Google Fonts import updated; homepage still uses Special Elite.

- **Refactors**
  - Set Marmelad as the global sans font in CSS variables and the universal selector.
  - Updated Google Fonts link to include Marmelad; kept Special Elite for the homepage.

<sup>Written for commit 03992725068f576c6230c41020e86d21a591b616. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

