### PR TITLE
feat: add direct E2B streaming to bypass Vercel timeout

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -137,9 +137,15 @@ export async function POST(request: NextRequest) {
       case 'stream':
         return handleStreamPost(request, body.sandboxId, body.prompt || '', body.images || [])
 
+      case 'start-stream-server':
+        return handleStartStreamServer(request, body.sandboxId)
+
+      case 'direct-stream':
+        return handleDirectStream(body.sandboxId, body.prompt || '', body.images || [])
+
       default:
         return NextResponse.json(
-          { error: 'Invalid action. Use: create, run, playwright, commit, push, diff, terminate, status, list' },
+          { error: 'Invalid action. Use: create, run, playwright, commit, push, diff, terminate, status, list, start-stream-server, direct-stream' },
           { status: 400 }
         )
     }
@@ -1857,6 +1863,391 @@ async function handleRestore(
     success: true,
     messageCount: formattedHistory.length,
     message: `Restored ${formattedHistory.length} messages to sandbox`
+  })
+}
+
+/**
+ * Start a direct streaming server inside the E2B sandbox
+ * This allows clients to connect directly to E2B, bypassing Vercel's timeout
+ *
+ * Returns the public URL that clients can connect to for streaming
+ */
+async function handleStartStreamServer(request: NextRequest, sandboxId: string) {
+  if (!sandboxId) {
+    return NextResponse.json(
+      { error: 'sandboxId is required' },
+      { status: 400 }
+    )
+  }
+
+  // Get Vercel AI Gateway API key
+  const aiGatewayKey = process.env.VERCEL_AI_GATEWAY_API_KEY
+  if (!aiGatewayKey) {
+    return NextResponse.json(
+      { error: 'VERCEL_AI_GATEWAY_API_KEY not configured' },
+      { status: 500 }
+    )
+  }
+
+  // Find sandbox entry
+  let sandboxEntry: (typeof activeSandboxes extends Map<string, infer V> ? V : never) | undefined = undefined
+
+  for (const [key, entry] of activeSandboxes.entries()) {
+    if (entry.sandboxId === sandboxId) {
+      sandboxEntry = entry
+      break
+    }
+  }
+
+  if (!sandboxEntry) {
+    // Try to reconnect
+    try {
+      console.log(`[Agent Cloud] Attempting to reconnect to sandbox: ${sandboxId}`)
+      const sandbox = await Sandbox.connect(sandboxId)
+      sandboxEntry = {
+        sandboxId,
+        sandbox,
+        createdAt: new Date(),
+        lastActivity: new Date(),
+        userId: 'reconnected',
+        conversationHistory: []
+      }
+    } catch (error) {
+      return NextResponse.json(
+        { error: 'Sandbox not found or expired' },
+        { status: 404 }
+      )
+    }
+  }
+
+  const { sandbox } = sandboxEntry
+  const workDir = sandboxEntry.repo?.cloned ? PROJECT_DIR : '/home/user'
+  const workingBranch = sandboxEntry.workingBranch || 'main'
+  const STREAM_SERVER_PORT = 3001
+
+  // Create the streaming server script
+  const streamServerScript = `#!/usr/bin/env node
+import express from 'express';
+import cors from 'cors';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: '50mb' }));
+
+const HISTORY_FILE = '${HISTORY_FILE}';
+const WORK_DIR = '${workDir}';
+const WORKING_BRANCH = '${workingBranch}';
+
+// Health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: Date.now() });
+});
+
+// Main streaming endpoint
+app.post('/stream', async (req, res) => {
+  const { prompt, images = [], systemPrompt: customSystemPrompt } = req.body;
+
+  if (!prompt && images.length === 0) {
+    return res.status(400).json({ error: 'prompt or images required' });
+  }
+
+  // Set up SSE headers
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  const send = (payload) => {
+    res.write('data: ' + JSON.stringify(payload) + '\\n\\n');
+  };
+
+  try {
+    send({ type: 'start', timestamp: Date.now() });
+    send({ type: 'log', message: 'Claude is thinking...' });
+
+    // Build conversation history
+    let conversationHistory = [];
+    try {
+      if (existsSync(HISTORY_FILE)) {
+        conversationHistory = JSON.parse(readFileSync(HISTORY_FILE, 'utf-8'));
+      }
+    } catch (e) {}
+
+    // Add user message to history
+    conversationHistory.push({ role: 'user', content: prompt, timestamp: new Date().toISOString() });
+
+    const MAX_PAIRS = 6;
+    const MAX_MSG_LENGTH = 800;
+    const recentHistory = conversationHistory.slice(-(MAX_PAIRS * 2));
+
+    let fullPrompt = prompt;
+    if (recentHistory.length > 2) {
+      const context = recentHistory.slice(0, -1)
+        .map(msg => {
+          const content = msg.content.length > MAX_MSG_LENGTH
+            ? msg.content.slice(0, MAX_MSG_LENGTH) + '...[truncated]'
+            : msg.content;
+          return (msg.role === 'user' ? 'Human' : 'Assistant') + ': ' + content;
+        })
+        .join('\\n\\n');
+      fullPrompt = 'Previous conversation:\\n' + context + '\\n\\nCurrent request: ' + prompt;
+    }
+
+    // Git workflow system prompt
+    const gitWorkflowPrompt = customSystemPrompt || \`
+IMPORTANT GIT WORKFLOW INSTRUCTIONS:
+- You are working on branch: \${WORKING_BRANCH}
+- BEFORE committing, ALWAYS configure git user: git config user.name "pipilot-swe-bot" && git config user.email "hello@pipilot.dev"
+- After making code changes, ALWAYS commit them with a clear message
+- After committing, push to the remote: git push -u origin \${WORKING_BRANCH}
+\`.trim();
+
+    // Configure MCP servers
+    const mcpServers = {};
+    if (process.env.MCP_GATEWAY_URL) {
+      mcpServers['tavily'] = { type: 'http', url: process.env.MCP_GATEWAY_URL };
+    }
+    if (process.env.GITHUB_TOKEN) {
+      mcpServers['github'] = {
+        type: 'http',
+        url: 'https://api.githubcopilot.com/mcp',
+        headers: { 'Authorization': 'Bearer ' + process.env.GITHUB_TOKEN }
+      };
+    }
+    mcpServers['playwright'] = { command: 'npx', args: ['@playwright/mcp@latest'] };
+
+    // Build prompt input
+    let promptInput;
+    if (images.length > 0) {
+      const gen = async function*() {
+        const contentParts = [];
+        for (const img of images) {
+          contentParts.push({
+            type: 'image',
+            source: { type: 'base64', media_type: img.type || 'image/png', data: img.data }
+          });
+        }
+        contentParts.push({ type: 'text', text: fullPrompt });
+        yield { type: 'user', message: { role: 'user', content: contentParts } };
+      };
+      promptInput = gen();
+    } else {
+      promptInput = fullPrompt;
+    }
+
+    let textContent = '';
+    let hasStreamedText = false;
+
+    // Start heartbeat
+    const heartbeat = setInterval(() => {
+      send({ type: 'heartbeat', timestamp: Date.now() });
+    }, 15000);
+
+    try {
+      for await (const message of query({
+        prompt: promptInput,
+        options: {
+          systemPrompt: gitWorkflowPrompt,
+          includePartialMessages: true,
+          permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+          ...(Object.keys(mcpServers).length > 0 ? {
+            mcpServers,
+            allowedTools: Object.keys(mcpServers).map(k => 'mcp__' + k + '__*')
+          } : {})
+        }
+      })) {
+        if (message.type === 'stream_event') {
+          const event = message.event;
+          if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+            hasStreamedText = true;
+            textContent += event.delta.text;
+            send({ type: 'text', data: event.delta.text, timestamp: Date.now() });
+          } else if (event.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+            send({ type: 'tool_use', name: event.content_block.name, input: {}, timestamp: Date.now() });
+          }
+        } else if (message.type === 'assistant') {
+          const content = message.message?.content;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (block.type === 'text' && block.text && !hasStreamedText) {
+                textContent += block.text;
+                send({ type: 'text', data: block.text, timestamp: Date.now() });
+              } else if (block.type === 'tool_use') {
+                send({ type: 'tool_use', name: block.name, input: block.input, timestamp: Date.now() });
+              }
+            }
+          }
+          hasStreamedText = false;
+        } else if (message.type === 'user') {
+          const content = message.message?.content;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              if (block.type === 'tool_result') {
+                let resultContent = '';
+                if (Array.isArray(block.content)) {
+                  resultContent = block.content.map(c => c.type === 'text' ? c.text : '[' + c.type + ']').join('\\n');
+                } else {
+                  resultContent = String(block.content);
+                }
+                send({ type: 'tool_result', result: resultContent.substring(0, 2000), timestamp: Date.now() });
+              }
+            }
+          }
+        } else if (message.type === 'result') {
+          send({ type: 'result', subtype: message.subtype, result: message.result, cost: message.total_cost_usd, timestamp: Date.now() });
+        }
+      }
+
+      // Save to conversation history
+      conversationHistory.push({ role: 'assistant', content: textContent, timestamp: new Date().toISOString() });
+      try {
+        writeFileSync(HISTORY_FILE, JSON.stringify(conversationHistory, null, 2));
+      } catch (e) {}
+
+      // Get git diff stats
+      let diffStats = { additions: 0, deletions: 0, filesChanged: 0 };
+      try {
+        const { execSync } = await import('child_process');
+        const diffOutput = execSync('git diff --shortstat HEAD~1 2>/dev/null || echo "0 0 0"', { cwd: WORK_DIR, encoding: 'utf-8' });
+        const match = diffOutput.match(/(\\d+) files? changed(?:, (\\d+) insertions?\\(\\+\\))?(?:, (\\d+) deletions?\\(-\\))?/);
+        if (match) {
+          diffStats = {
+            filesChanged: parseInt(match[1]) || 0,
+            additions: parseInt(match[2]) || 0,
+            deletions: parseInt(match[3]) || 0
+          };
+        }
+      } catch (e) {}
+
+      send({ type: 'complete', diff: diffStats, timestamp: Date.now() });
+    } finally {
+      clearInterval(heartbeat);
+    }
+
+    res.end();
+  } catch (error) {
+    send({ type: 'error', message: error.message || String(error), timestamp: Date.now() });
+    res.end();
+  }
+});
+
+const PORT = ${STREAM_SERVER_PORT};
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(JSON.stringify({ type: 'server_ready', port: PORT, timestamp: Date.now() }));
+});
+`
+
+  try {
+    // Upload the streaming server script
+    await sandbox.files.write(`${workDir}/stream-server.mjs`, streamServerScript)
+    console.log(`[Agent Cloud] Stream server script uploaded`)
+
+    // Install dependencies and start the server in background
+    const installCommand = `cd ${workDir} && ([ -f package.json ] || echo '{"type":"module"}' > package.json) && pnpm add express cors @anthropic-ai/claude-agent-sdk 2>&1`
+
+    console.log(`[Agent Cloud] Installing stream server dependencies...`)
+    await sandbox.commands.run(installCommand, {
+      cwd: workDir,
+      timeoutMs: 60000
+    })
+
+    // Start the server in background with environment variables
+    const startCommand = `cd ${workDir} && nohup node stream-server.mjs > /tmp/stream-server.log 2>&1 &`
+
+    await sandbox.commands.run(startCommand, {
+      cwd: workDir,
+      timeoutMs: 10000,
+      envs: {
+        ANTHROPIC_BASE_URL: AI_GATEWAY_BASE_URL,
+        ANTHROPIC_AUTH_TOKEN: aiGatewayKey,
+        ANTHROPIC_API_KEY: '',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: AVAILABLE_MODELS.sonnet,
+        ANTHROPIC_DEFAULT_OPUS_MODEL: AVAILABLE_MODELS.opus,
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: AVAILABLE_MODELS.haiku,
+        PLAYWRIGHT_BROWSERS_PATH: '0',
+        ...(sandboxEntry.mcpGatewayUrl ? { MCP_GATEWAY_URL: sandboxEntry.mcpGatewayUrl } : {}),
+      }
+    })
+
+    // Wait for server to be ready
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    // Get the public URL for the streaming port
+    let streamUrl: string
+    try {
+      if (typeof sandbox.getHost === 'function') {
+        streamUrl = `https://${sandbox.getHost(STREAM_SERVER_PORT)}`
+      } else {
+        // Fallback URL construction
+        streamUrl = `https://${sandboxId}-${STREAM_SERVER_PORT}.e2b.dev`
+      }
+    } catch (e) {
+      streamUrl = `https://${sandboxId}-${STREAM_SERVER_PORT}.e2b.dev`
+    }
+
+    console.log(`[Agent Cloud] Stream server started at: ${streamUrl}`)
+
+    return NextResponse.json({
+      success: true,
+      streamUrl,
+      port: STREAM_SERVER_PORT,
+      message: 'Stream server started. Connect directly to streamUrl for streaming.'
+    })
+
+  } catch (error) {
+    console.error('[Agent Cloud] Failed to start stream server:', error)
+    return NextResponse.json(
+      { error: `Failed to start stream server: ${error instanceof Error ? error.message : 'Unknown error'}` },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * Handle direct stream request (used internally by the E2B stream server)
+ * This is a quick action that returns connection info without starting a new server
+ */
+async function handleDirectStream(sandboxId: string, prompt: string, images: Array<{ data: string; type: string }>) {
+  // Find sandbox to get its stream URL
+  let sandboxEntry: (typeof activeSandboxes extends Map<string, infer V> ? V : never) | undefined = undefined
+
+  for (const [key, entry] of activeSandboxes.entries()) {
+    if (entry.sandboxId === sandboxId) {
+      sandboxEntry = entry
+      break
+    }
+  }
+
+  if (!sandboxEntry) {
+    return NextResponse.json(
+      { error: 'Sandbox not found. Call start-stream-server first.' },
+      { status: 404 }
+    )
+  }
+
+  const STREAM_SERVER_PORT = 3001
+  let streamUrl: string
+
+  try {
+    const { sandbox } = sandboxEntry
+    if (typeof sandbox.getHost === 'function') {
+      streamUrl = `https://${sandbox.getHost(STREAM_SERVER_PORT)}`
+    } else {
+      streamUrl = `https://${sandboxId}-${STREAM_SERVER_PORT}.e2b.dev`
+    }
+  } catch (e) {
+    streamUrl = `https://${sandboxId}-${STREAM_SERVER_PORT}.e2b.dev`
+  }
+
+  return NextResponse.json({
+    success: true,
+    streamUrl,
+    port: STREAM_SERVER_PORT,
+    sandboxId,
+    message: 'POST to streamUrl/stream with { prompt, images } to start streaming directly from E2B'
   })
 }
 


### PR DESCRIPTION
- Added start-stream-server action that creates Express server in E2B sandbox
- Server exposes /stream endpoint on port 3001 with public E2B URL
- Frontend now connects directly to E2B for streaming (no Vercel proxy)
- Falls back to proxied streaming if direct connection fails
- Eliminates 5-minute Vercel timeout for long-running agent tasks

Architecture:
- Vercel API: Only creates sandbox and returns E2B stream URL
- E2B Sandbox: Runs Express server that handles Claude Agent SDK streaming
- Client: Connects directly to E2B URL for unlimited streaming duration

https://claude.ai/code/session_01CBJNi6WboPyPP4CMYJTJSR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable direct streaming from E2B sandboxes to bypass Vercel’s 5‑minute timeout. The client now connects to a per-sandbox SSE server for long-running agent tasks, with a safe fallback to the Vercel proxy.

- **New Features**
  - Added start-stream-server action to spin up an Express server in the sandbox exposing POST /stream on port 3001.
  - Frontend requests a public E2B streamUrl, then streams directly via streamUrl/stream (no Vercel proxy).
  - Falls back to existing proxied streaming if the direct connection fails.
  - Vercel API now only creates the sandbox and returns the E2B streamUrl.

- **Migration**
  - Requires VERCEL_AI_GATEWAY_API_KEY to be set in the environment.

<sup>Written for commit e449a823a17b4cf6415596c53c82f9c43456d0b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

