### PR TITLE
fix: remove timeout for stream server dependency installation

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -2151,7 +2151,7 @@ app.listen(PORT, '0.0.0.0', () => {
     console.log(`[Agent Cloud] Installing stream server dependencies...`)
     await sandbox.commands.run(installCommand, {
       cwd: workDir,
-      timeoutMs: 60000
+      timeoutMs: 0 // No timeout - installation can take a while
     })
 
     // Start the server in background with environment variables


### PR DESCRIPTION
Installation of express, cors, and claude-agent-sdk can take longer than 60 seconds, causing timeout errors. Set timeoutMs to 0 to allow unlimited time for installation.

https://claude.ai/code/session_01CBJNi6WboPyPP4CMYJTJSR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 60s timeout for stream server dependency installation to prevent setup failures on slow networks. Installation now waits indefinitely until express, cors, and claude-agent-sdk are installed.

<sup>Written for commit 93b4c288ac8176aa7f97834729188f78da9b5666. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

