### PR TITLE
fix: remove verbose debug logging from subscription cache and token h…

### DIFF
--- a/hooks/use-supabase-token.ts
+++ b/hooks/use-supabase-token.ts
@@ -43,7 +43,6 @@ export function useSupabaseToken(): UseSupabaseTokenReturn {
         setToken(null)
       }
     } catch (err) {
-      console.error('Error checking token status:', err)
       setError(err instanceof Error ? err.message : 'Unknown error')
       setIsExpired(true)
       setToken(null)
@@ -70,7 +69,6 @@ export function useSupabaseToken(): UseSupabaseTokenReturn {
         throw new Error('Failed to refresh token')
       }
     } catch (err) {
-      console.error('Error refreshing token:', err)
       setError(err instanceof Error ? err.message : 'Failed to refresh token')
       setIsExpired(true)
       setToken(null)
@@ -105,7 +103,6 @@ export function useSupabaseToken(): UseSupabaseTokenReturn {
   // Auto-refresh token if it's expired
   useEffect(() => {
     if (isExpired && !isLoading) {
-      console.log('[USE-SUPABASE-TOKEN] Token expired, attempting auto-refresh')
       refreshToken()
     }
   }, [isExpired, isLoading, refreshToken])


### PR DESCRIPTION
…ooks

Cleaned up console.log and console.error statements from:
- hooks/use-subscription-cache.ts - removed [SubscriptionCache] logs
- hooks/use-supabase-token.ts - removed [USE-SUPABASE-TOKEN] logs and error logs

https://claude.ai/code/session_01CBJNi6WboPyPP4CMYJTJSR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed verbose debug logs from subscription cache and Supabase token hooks to keep console output clean in production. Non-critical session storage and fetch errors now fail silently; hook behavior and state updates are unchanged.

<sup>Written for commit 7af627aae6e80774ac649cd155e7eafb085b014a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

