### PR TITLE
fix: prevent text duplication in agent-cloud streaming

### DIFF
--- a/app/api/agent-cloud/route.ts
+++ b/app/api/agent-cloud/route.ts
@@ -495,19 +495,16 @@ try {
         console.log(JSON.stringify({ type: 'tool_use', name: event.content_block.name, input: {}, timestamp: Date.now() }));
       }
     } else if (message.type === 'assistant') {
+      // IMPORTANT: Only process tool_use blocks here - text is already streamed via stream_event
+      // Do NOT emit text from assistant messages to avoid duplication in multi-turn conversations
       const content = message.message?.content;
       if (Array.isArray(content)) {
         for (const block of content) {
-          if (block.type === 'text' && block.text && !hasStreamedText) {
-            // Only emit text from assistant if we haven't already streamed it
-            console.log(JSON.stringify({ type: 'text', data: block.text, timestamp: Date.now() }));
-          } else if (block.type === 'tool_use') {
+          if (block.type === 'tool_use') {
             console.log(JSON.stringify({ type: 'tool_use', name: block.name, input: block.input, timestamp: Date.now() }));
           }
         }
       }
-      // Reset for next turn (multi-turn conversations)
-      hasStreamedText = false;
     } else if (message.type === 'user') {
       // User messages contain tool_result blocks
       const content = message.message?.content;


### PR DESCRIPTION
The issue was that text was being emitted twice in multi-turn conversations:
1. First from stream_event deltas (correct)
2. Again from assistant messages when hasStreamedText was reset

The fix removes text emission from assistant messages entirely - only tool_use blocks are processed there. Text is exclusively streamed via stream_event deltas, which is the same approach used in stream-server.mjs.

This fixes the bug where responses like "Good! I can see..." would appear twice in a row without any separator.

https://claude.ai/code/session_01Mau5gbdvDmn6nbgWaQ3UQE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate text in agent-cloud multi-turn streaming by sending text only via stream_event deltas and not from assistant messages. Assistant messages now handle tool_use blocks only, fixing repeated responses like “Good! I can see…”.

<sup>Written for commit 822c3781dfa81bd9f98eb52519c3089e85af9aa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

