### PR TITLE
fix: session page crash and settings save indicator

### DIFF
--- a/app/agent-cloud/session/page.tsx
+++ b/app/agent-cloud/session/page.tsx
@@ -1147,20 +1147,7 @@ User Request: ${currentPrompt}`
     }
   }, [isScreenSharing])
 
-  // Auto-resume screen sharing if coming from new page with sharing active
-  useEffect(() => {
-    const shouldResume = sessionStorage.getItem('agent-cloud-resume-sharing')
-    if (shouldResume === 'true') {
-      sessionStorage.removeItem('agent-cloud-resume-sharing')
-      // Small delay to let the page settle, then prompt for sharing
-      const timer = setTimeout(() => {
-        handleScreenToggle()
-      }, 500)
-      return () => clearTimeout(timer)
-    }
-  }, [])
-
-  const handleScreenToggle = async () => {
+  const handleScreenToggle = useCallback(async () => {
     if (isScreenSharing) {
       // Stop screen sharing
       if (mediaStreamRef.current) {
@@ -1213,7 +1200,20 @@ User Request: ${currentPrompt}`
     } finally {
       setIsCapturing(false)
     }
-  }
+  }, [isScreenSharing])
+
+  // Auto-resume screen sharing if coming from new page with sharing active
+  useEffect(() => {
+    const shouldResume = sessionStorage.getItem('agent-cloud-resume-sharing')
+    if (shouldResume === 'true') {
+      sessionStorage.removeItem('agent-cloud-resume-sharing')
+      // Small delay to let the page settle, then prompt for sharing
+      const timer = setTimeout(() => {
+        handleScreenToggle()
+      }, 500)
+      return () => clearTimeout(timer)
+    }
+  }, [handleScreenToggle])
 
   // Render message line
   const renderLine = (line: TerminalLine, index: number) => {

--- a/app/agent-cloud/settings/page.tsx
+++ b/app/agent-cloud/settings/page.tsx
@@ -79,9 +79,27 @@ export default function SettingsPage() {
     })
   }
 
+  // Track if settings have changed (for visual feedback)
+  const [isSaved, setIsSaved] = useState(false)
+
+  // Show saved indicator briefly when connectors change
+  useEffect(() => {
+    // Skip the initial render
+    const hasValues = connectors.some(c => c.enabled || c.fields.some(f => f.value))
+    if (hasValues) {
+      setIsSaved(true)
+      const timer = setTimeout(() => setIsSaved(false), 2000)
+      return () => clearTimeout(timer)
+    }
+  }, [connectors])
+
   // Save and show toast
   const handleSave = () => {
-    toast.success('Settings saved')
+    // Settings are auto-saved via layout's useEffect
+    // This button just provides explicit confirmation
+    setIsSaved(true)
+    toast.success('Settings saved successfully')
+    setTimeout(() => setIsSaved(false), 2000)
   }
 
   // Get enabled connector count
@@ -183,14 +201,24 @@ export default function SettingsPage() {
           </div>
         </section>
 
-        {/* Save button */}
-        <div className="flex justify-end">
+        {/* Save button with visual feedback */}
+        <div className="flex items-center justify-end gap-3">
+          {isSaved && (
+            <span className="text-sm text-green-400 flex items-center gap-1 animate-in fade-in duration-200">
+              <Check className="h-4 w-4" />
+              Saved
+            </span>
+          )}
           <Button
             onClick={handleSave}
-            className="bg-orange-500 hover:bg-orange-600 text-white rounded-xl px-6"
+            className={`rounded-xl px-6 transition-all duration-200 ${
+              isSaved
+                ? 'bg-green-600 hover:bg-green-700'
+                : 'bg-orange-500 hover:bg-orange-600'
+            } text-white`}
           >
             <Check className="h-4 w-4 mr-2" />
-            Save Settings
+            {isSaved ? 'Saved!' : 'Save Settings'}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Session Page:
- Fixed "Cannot access before initialization" error caused by useEffect calling handleScreenToggle before it was defined
- Converted handleScreenToggle to useCallback
- Moved auto-resume effect after function definition
- Added handleScreenToggle to effect dependency array

Settings Page:
- Added visual feedback when settings are saved
- Button changes to green "Saved!" state after saving
- Shows "Saved" indicator next to button
- Auto-saves via layout's useEffect (button confirms to user)

https://claude.ai/code/session_01MmX8Fp1jd8y5jz3J9UDGfg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the session page crash during screen-share auto-resume and adds clear “Saved” feedback on the settings page.

- **Bug Fixes**
  - Fixed “Cannot access before initialization” by converting handleScreenToggle to useCallback.
  - Moved the auto-resume effect after the function and added handleScreenToggle to its dependency array to avoid premature calls.

- **New Features**
  - Save button now shows a green “Saved!” state and a “Saved” label for 2 seconds.
  - Settings still auto-save; the button provides explicit confirmation.

<sup>Written for commit 7758c8679cbe86e7ee97df13b29c1f1a89a3d6e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

