### PR TITLE
feat: use external Supabase project for agent cloud storage

### DIFF
--- a/lib/supabase/agent-cloud-client.ts
+++ b/lib/supabase/agent-cloud-client.ts
@@ -1,0 +1,10 @@
+import { createBrowserClient } from "@supabase/ssr"
+
+// External Supabase project for Agent Cloud storage
+// This is separate from the main auth project to handle large session data
+const AGENT_CLOUD_SUPABASE_URL = 'https://dlunpilhklsgvkegnnlp.supabase.co'
+const AGENT_CLOUD_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRsdW5waWxoa2xzZ3ZrZWdubmxwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUwNTA0MTksImV4cCI6MjA3MDYyNjQxOX0.rhLN_bhvH9IWPkyHiohrOQbY9D34RSeSLzURhAyZPds'
+
+export function createAgentCloudClient() {
+  return createBrowserClient(AGENT_CLOUD_SUPABASE_URL, AGENT_CLOUD_SUPABASE_ANON_KEY)
+}


### PR DESCRIPTION
The agent cloud storage now uses a dedicated external Supabase project separate from the main auth project. This provides better scalability for large session data without affecting the main application database.

Changes:
- Added lib/supabase/agent-cloud-client.ts - dedicated client for storage
- Updated agent-cloud-storage.ts to use two clients:
  - authClient: main project for user authentication
  - storageClient: external project for session/message storage

https://claude.ai/code/session_01MmX8Fp1jd8y5jz3J9UDGfg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Agent Cloud storage to a dedicated external Supabase project, while keeping user auth on the main project. This scales large session/message data and isolates it from the main app database.

- **Refactors**
  - Added lib/supabase/agent-cloud-client.ts for the external storage client.
  - Updated lib/agent-cloud-storage.ts to use two clients: authClient (user ID) and storageClient (sessions, messages, images, connectors).

<sup>Written for commit ecf2f7b3fc4a56c2d803a2b40e0ae9b16b31caea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

