### PR TITLE
fix: use @supabase/supabase-js for external storage client

### DIFF
--- a/lib/supabase/agent-cloud-client.ts
+++ b/lib/supabase/agent-cloud-client.ts
@@ -1,10 +1,16 @@
-import { createBrowserClient } from "@supabase/ssr"
+import { createClient } from "@supabase/supabase-js"
 
 // External Supabase project for Agent Cloud storage
 // This is separate from the main auth project to handle large session data
 const AGENT_CLOUD_SUPABASE_URL = 'https://dlunpilhklsgvkegnnlp.supabase.co'
 const AGENT_CLOUD_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRsdW5waWxoa2xzZ3ZrZWdubmxwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUwNTA0MTksImV4cCI6MjA3MDYyNjQxOX0.rhLN_bhvH9IWPkyHiohrOQbY9D34RSeSLzURhAyZPds'
 
+// Singleton instance to avoid creating multiple clients
+let agentCloudClient: ReturnType<typeof createClient> | null = null
+
 export function createAgentCloudClient() {
-  return createBrowserClient(AGENT_CLOUD_SUPABASE_URL, AGENT_CLOUD_SUPABASE_ANON_KEY)
+  if (!agentCloudClient) {
+    agentCloudClient = createClient(AGENT_CLOUD_SUPABASE_URL, AGENT_CLOUD_SUPABASE_ANON_KEY)
+  }
+  return agentCloudClient
 }


### PR DESCRIPTION
Switch from @supabase/ssr's createBrowserClient to the standard @supabase/supabase-js createClient to avoid SSR caching issues that were causing requests to go to the wrong Supabase project.

Also added singleton pattern to avoid creating multiple clients.

https://claude.ai/code/session_01MmX8Fp1jd8y5jz3J9UDGfg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Agent Cloud storage to use @supabase/supabase-js createClient to fix SSR caching that routed requests to the wrong project. Added a singleton to reuse the client and avoid duplicates.

- **Bug Fixes**
  - Replaced createBrowserClient (@supabase/ssr) with createClient (@supabase/supabase-js) to prevent cross-request cache bleed and ensure correct project routing.
  - Introduced a module-level singleton to avoid creating multiple clients.

<sup>Written for commit 7a91fea4c01df2fc2f337647c4a1f111bd6677ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

