### PR TITLE
fix: handle missing sessions gracefully in Supabase storage

### DIFF
--- a/app/agent-cloud/layout.tsx
+++ b/app/agent-cloud/layout.tsx
@@ -689,9 +689,13 @@ function AgentCloudLayoutInner({
         ]
       }
 
-      // Save to Supabase
+      // Save to Supabase - only proceed if save succeeds
       const saved = await agentCloudStorage.createSession(newSession)
-      if (saved) {
+      if (!saved) {
+        console.error('[AgentCloud] Failed to save session to Supabase')
+        // Still add to local state but warn user
+        toast.warning('Session created locally but cloud sync failed')
+      } else {
         // Track lines count for this session
         setLastSavedLinesCount(prev => {
           const updated = new Map(prev)

--- a/lib/agent-cloud-storage.ts
+++ b/lib/agent-cloud-storage.ts
@@ -316,6 +316,19 @@ class AgentCloudStorage {
       const newLines = lines.slice(startIndex)
       if (newLines.length === 0) return true
 
+      // Check if session exists in Supabase first (avoid foreign key errors)
+      const { data: existingSession } = await this.storageClient
+        .from('agent_cloud_sessions')
+        .select('id')
+        .eq('id', sessionId)
+        .single()
+
+      if (!existingSession) {
+        // Session doesn't exist in Supabase - skip silently (local-only session)
+        console.log('[AgentCloudStorage] Session not in DB, skipping message save:', sessionId)
+        return false
+      }
+
       // Prepare messages
       const messages = newLines.map((line, idx) => ({
         session_id: sessionId,


### PR DESCRIPTION
- Added session existence check before saving messages to avoid foreign key constraint errors
- Better error handling when session creation fails
- Log when skipping message saves for local-only sessions

This fixes the 409 Conflict errors when sessions exist locally but not in Supabase (e.g., created before schema was fixed).

https://claude.ai/code/session_01MmX8Fp1jd8y5jz3J9UDGfg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 409/conflict errors when sessions exist locally but not in Supabase by checking session existence before saving messages and handling failed session creation gracefully. If cloud save fails, the session stays local and the user sees a warning.

- **Bug Fixes**
  - Verify session exists in Supabase before saving messages; skip and log if missing to avoid foreign key errors.
  - On session creation failure, keep session in local state, log the error, and show a toast warning.

<sup>Written for commit 00b87cd6b2baa53aee1bac55de5f9f957c88c69b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

