### PR TITLE
feat: auto-switch to preview tab when AI starts streaming

### DIFF
--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -363,6 +363,19 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
       }
     }
 
+    // Auto-switch to preview tab when AI starts streaming so the user
+    // sees the AI responding view (rocket + witty messages) immediately.
+    // Skip if a live preview is already loaded to avoid hiding it.
+    const handleAiStreamingState = (event: CustomEvent) => {
+      const { isStreaming } = event.detail
+      if (isStreaming && !codePreviewRef.current?.preview?.url) {
+        setActiveTab('preview')
+        if (isMobile) {
+          setMobileTab('preview')
+        }
+      }
+    }
+
     // Handle opening file from search results or other sources
     const handleOpenFileInEditor = async (event: CustomEvent) => {
       const { filePath, lineNumber } = event.detail
@@ -409,6 +422,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
     window.addEventListener('preview-starting', handlePreviewStarting as EventListener)
     window.addEventListener('preview-stopped', handlePreviewStopped as EventListener)
     window.addEventListener('ai-stream-complete', handleAiStreamComplete as EventListener)
+    window.addEventListener('ai-streaming-state', handleAiStreamingState as EventListener)
     window.addEventListener('openFileInEditor', handleOpenFileInEditor as EventListener)
 
     return () => {
@@ -418,6 +432,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
       window.removeEventListener('preview-starting', handlePreviewStarting as EventListener)
       window.removeEventListener('preview-stopped', handlePreviewStopped as EventListener)
       window.removeEventListener('ai-stream-complete', handleAiStreamComplete as EventListener)
+      window.removeEventListener('ai-streaming-state', handleAiStreamingState as EventListener)
       window.removeEventListener('openFileInEditor', handleOpenFileInEditor as EventListener)
     }
   }, [selectedProject, isMobile, toast])


### PR DESCRIPTION
Listen for 'ai-streaming-state' event in workspace layout and automatically switch to the preview tab when AI starts processing, so users immediately see the rocket + witty messages view without needing to manually switch tabs first.

Skips auto-switching if a live preview URL is already loaded to avoid hiding an active preview.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-switches to the Preview tab when AI starts streaming so users immediately see the responding view. Skips auto-switching if a live preview is already active.

- **New Features**
  - Listens for the 'ai-streaming-state' event in WorkspaceLayout and switches to Preview (desktop and mobile).
  - Adds event listener setup and cleanup for 'ai-streaming-state'.

<sup>Written for commit fd459620588d5d6ca2051de21fdd74ca9478c7ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

