### PR TITLE
fix: pass isAIStreaming as prop to fix race condition on tab switch

### DIFF
--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -118,6 +118,7 @@ interface CodePreviewPanelProps {
   onApplyTheme?: (theme: Theme, cssContent: string) => Promise<boolean>;
   onTagToChat?: (component: { id: string; tagName: string; sourceFile?: string; sourceLine?: number; className: string; textContent?: string }) => void;
   onPublish?: () => void;
+  isAIStreaming?: boolean;
 }
 
 export interface CodePreviewPanelRef {
@@ -847,7 +848,7 @@ function PreviewEmptyState({ projectName, onStartPreview, disabled }: {
 }
 
 export const CodePreviewPanel = forwardRef<CodePreviewPanelRef, CodePreviewPanelProps>(
-  ({ project, activeTab, onTabChange, previewViewMode = "desktop", syncedUrl, onUrlChange, onVisualEditorSave, onApplyTheme, onTagToChat, onPublish }, ref) => {
+  ({ project, activeTab, onTabChange, previewViewMode = "desktop", syncedUrl, onUrlChange, onVisualEditorSave, onApplyTheme, onTagToChat, onPublish, isAIStreaming = false }, ref) => {
     const { toast } = useToast();
     const isMobile = useIsMobile();
     const [preview, setPreview] = useState<PreviewState>({
@@ -870,7 +871,6 @@ export const CodePreviewPanel = forwardRef<CodePreviewPanelRef, CodePreviewPanel
   const resizeRef = useRef<HTMLDivElement>(null)
   const [browserLogs, setBrowserLogs] = useState<string[]>([])
   const [isExpoProject, setIsExpoProject] = useState(false)
-  const [isAIStreaming, setIsAIStreaming] = useState(false)
   const browserLogsRef = useRef<HTMLDivElement>(null)
   const [isStackBlitzOpen, setIsStackBlitzOpen] = useState(false)
   const [backgroundProcess, setBackgroundProcess] = useState<{
@@ -984,16 +984,6 @@ export const CodePreviewPanel = forwardRef<CodePreviewPanelRef, CodePreviewPanel
       consoleRef.current.scrollTop = consoleRef.current.scrollHeight
     }
   }, [consoleOutput, browserLogs, processLogs, isConsoleOpen])
-
-  // Listen for AI streaming state from chat panel
-  useEffect(() => {
-    const handleAIStreaming = (e: Event) => {
-      const detail = (e as CustomEvent).detail
-      setIsAIStreaming(detail?.isStreaming ?? false)
-    }
-    window.addEventListener('ai-streaming-state', handleAIStreaming)
-    return () => window.removeEventListener('ai-streaming-state', handleAIStreaming)
-  }, [])
 
   // Set up iframe message listener for browser logs
   useEffect(() => {

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -312,6 +312,9 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
   // Preview view mode state
   const [previewViewMode, setPreviewViewMode] = useState<'desktop' | 'mobile'>('desktop')
 
+  // Track AI streaming state (always mounted, unlike CodePreviewPanel)
+  const [isAIStreaming, setIsAIStreaming] = useState(false)
+
   // Listen for preview state changes from CodePreviewPanel
   useEffect(() => {
     const handlePreviewStateChange = (event: CustomEvent) => {
@@ -368,6 +371,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
     // Skip if a live preview is already loaded to avoid hiding it.
     const handleAiStreamingState = (event: CustomEvent) => {
       const { isStreaming } = event.detail
+      setIsAIStreaming(isStreaming)
       if (isStreaming && !codePreviewRef.current?.preview?.url) {
         setActiveTab('preview')
         if (isMobile) {
@@ -1148,10 +1152,11 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                           // Trigger preview creation
                           codePreviewRef.current?.createPreview()
                         }}
+                        isAIStreaming={isAIStreaming}
                       />
                     ) : activeTab === "cloud" ? (
                       /* Cloud Tab */
-                      <CloudTab user={user} selectedProject={selectedProject} /> 
+                      <CloudTab user={user} selectedProject={selectedProject} />
                     ) : activeTab === "audit" ? (
                       /* Audit Tab */
                       <AuditTab user={user} selectedProject={selectedProject} />
@@ -1623,10 +1628,11 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                       onUrlChange={setCustomUrl}
                       onVisualEditorSave={handleVisualEditorSave}
                       onApplyTheme={handleVisualEditorThemeSave}
+                      isAIStreaming={isAIStreaming}
                     />
                   </div>
                 </TabsContent>
-                
+
                 <TabsContent value="cloud" className="flex-1 m-0 data-[state=active]:flex data-[state=active]:flex-col">
                   <div className="h-full overflow-hidden">
                     <CloudTab user={user} selectedProject={selectedProject} />


### PR DESCRIPTION
CodePreviewPanel was conditionally rendered (activeTab === "preview"), so its event listener for 'ai-streaming-state' didn't exist when the tab switched. The event fired before the component mounted, leaving isAIStreaming as false and showing the empty state instead.

Fix: Track isAIStreaming in workspace-layout.tsx (always mounted) and pass it as a prop to CodePreviewPanel. Remove the local state and event listener from CodePreviewPanel.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a tab-switch race condition that made the Preview panel show the empty state while streaming. Streaming state is now tracked in WorkspaceLayout and passed down as a prop, replacing the local state and event listener in CodePreviewPanel.

<sup>Written for commit 5c5eb0d3778ac054538b4b6fcbdf0078de4439d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

