### PR TITLE
fix: persist inline tool pill positions across page refresh

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -2299,7 +2299,9 @@ export function ChatPanelV2({
           ? { success: true }
           : (tool.status === 'failed'
             ? { error: 'Tool execution failed' }
-            : undefined)
+            : undefined),
+        textPosition: tool.textPosition,
+        reasoningPosition: tool.reasoningPosition,
       }))
 
       if (finalContent.trim() || toolInvocationsData.length > 0) {
@@ -2627,6 +2629,8 @@ export function ChatPanelV2({
           toolCallId: string
           input?: any
           status: 'executing' | 'completed' | 'failed'
+          textPosition?: number
+          reasoningPosition?: number
         }>>()
 
         uiMessages.forEach((msg: any) => {
@@ -2660,7 +2664,9 @@ export function ChatPanelV2({
                 toolName: inv.toolName,
                 toolCallId: inv.toolCallId,
                 input: inv.args,
-                status
+                status,
+                textPosition: inv.textPosition,
+                reasoningPosition: inv.reasoningPosition,
               }
             })
 
@@ -2925,14 +2931,16 @@ export function ChatPanelV2({
       // Continuation complete - update the original message with combined content
       // Get tool invocations for this message from activeToolCalls
       const toolInvocationsForMessage = activeToolCalls.get(assistantMessageId) || []
-      
+
       // Convert to the format expected by the database
       const toolInvocationsData = toolInvocationsForMessage.map(tool => ({
         toolName: tool.toolName,
         toolCallId: tool.toolCallId,
         args: tool.input,
         state: tool.status === 'completed' ? 'result' : 'call',
-        result: tool.status === 'completed' ? { success: true } : (tool.status === 'failed' ? { error: 'Tool execution failed' } : undefined)
+        result: tool.status === 'completed' ? { success: true } : (tool.status === 'failed' ? { error: 'Tool execution failed' } : undefined),
+        textPosition: tool.textPosition,
+        reasoningPosition: tool.reasoningPosition,
       }))
       
       if (accumulatedContent.trim() || toolInvocationsData.length > 0) {
@@ -4518,7 +4526,9 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
         toolCallId: tool.toolCallId,
         args: tool.input,
         state: tool.status === 'completed' ? 'result' : 'call',
-        result: tool.status === 'completed' ? { success: true } : (tool.status === 'failed' ? { error: 'Tool execution failed' } : undefined)
+        result: tool.status === 'completed' ? { success: true } : (tool.status === 'failed' ? { error: 'Tool execution failed' } : undefined),
+        textPosition: tool.textPosition,
+        reasoningPosition: tool.reasoningPosition,
       }))
 
       console.log(`[ChatPanelV2][Save] Tool invocations data for database:`, toolInvocationsData)


### PR DESCRIPTION
Inline pills (tool invocations rendered at their exact position in the AI response) were lost on refresh because textPosition and reasoningPosition were never saved to the database.

- Save: include textPosition/reasoningPosition in all 3 tool invocation serialization paths (main stream, continuation, and stop handler)
- Load: restore textPosition/reasoningPosition from saved metadata when rebuilding activeToolCalls map on message load

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist inline tool pill positions across page refresh by saving and restoring textPosition and reasoningPosition for tool invocations. Pills now stay anchored to their exact spots after reload.

- **Bug Fixes**
  - Save: include textPosition/reasoningPosition in tool invocation serialization for main stream, continuation, and stop handler.
  - Load: restore positions from saved metadata when rebuilding activeToolCalls on message load.

<sup>Written for commit b2f6bf938adcb0d341c54acdfd0a0ad6131801fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

