### PR TITLE
Claude/fix aiprompt error jq po m

### DIFF
--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -1747,6 +1747,25 @@ export const CodePreviewPanel = forwardRef<CodePreviewPanelRef, CodePreviewPanel
       // (Sandpack's bundler doesn't use it the same way Vite does)
       delete spFiles['/index.html']
 
+      // Step 4: Create root-level bridge files to override template defaults
+      // The react-ts template has /App.tsx at root which shows "Hello World".
+      // Our project files are at /src/App.tsx. We need a root /App.tsx that imports from src.
+      if (spFiles['/src/App.tsx'] && !spFiles['/App.tsx']) {
+        spFiles['/App.tsx'] = {
+          code: `// Bridge file: re-exports App from src folder
+export { default } from './src/App';
+export * from './src/App';`
+        }
+        console.log('[Sandpack] Created bridge /App.tsx → /src/App.tsx')
+      } else if (spFiles['/src/App.jsx'] && !spFiles['/App.jsx']) {
+        spFiles['/App.jsx'] = {
+          code: `// Bridge file: re-exports App from src folder
+export { default } from './src/App';
+export * from './src/App';`
+        }
+        console.log('[Sandpack] Created bridge /App.jsx → /src/App.jsx')
+      }
+
       // Debug: Log the key files to verify they're correct
       console.log('[Sandpack] Entry file:', entryFile)
       console.log('[Sandpack] Has /src/App.tsx:', !!spFiles['/src/App.tsx'])


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Sandpack preview rendering the template “Hello World” by using the project’s real entry and App component. Adds explicit entry selection and a bridge App file, with targeted logging to diagnose file loading issues.

- **Bug Fixes**
  - Detect the correct entry file and pass it via customSetup.entry.
  - Map Vite /src/main.* to /src/index.* when needed.
  - Create a root-level bridge /App.* that re-exports from /src/App.* to override the template.
  - Add logs for critical files and entry selection to track why files might be skipped.

<sup>Written for commit 2e96e0b724c67e43897e9465610441832e75f91b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

