### PR TITLE
fix: convert shadcn/ui @apply directives to CSS for Sandpack

### DIFF
--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -1751,14 +1751,18 @@ export const CodePreviewPanel = forwardRef<CodePreviewPanelRef, CodePreviewPanel
           transformedContent = resolvePathAliases(file.content, spPath)
         }
 
-        // Process CSS files: strip Tailwind directives (CDN auto-injects base styles)
-        // and convert @apply to inline styles where possible
+        // Process CSS files: strip Tailwind directives and convert @apply for shadcn/ui
         if (ext === 'css') {
           transformedContent = transformedContent
             // Remove @tailwind directives - CDN handles these automatically
             .replace(/@tailwind\s+(base|components|utilities)\s*;?/g, '')
-            // Remove @layer directives but keep content
-            .replace(/@layer\s+(base|components|utilities)\s*\{/g, '/* @layer $1 */ {')
+            // Remove @layer wrappers but keep the content inside
+            .replace(/@layer\s+(base|components|utilities)\s*\{([\s\S]*?)\n\}/g, '$2')
+            // Convert common @apply directives to actual CSS (shadcn/ui patterns)
+            .replace(/@apply\s+border-border\s*;?/g, 'border-color: hsl(var(--border));')
+            .replace(/@apply\s+bg-background\s+text-foreground\s*;?/g, 'background-color: hsl(var(--background)); color: hsl(var(--foreground));')
+            .replace(/@apply\s+bg-background\s*;?/g, 'background-color: hsl(var(--background));')
+            .replace(/@apply\s+text-foreground\s*;?/g, 'color: hsl(var(--foreground));')
           console.log('[Sandpack] Processed CSS file:', spPath)
         }
 


### PR DESCRIPTION
Handle common shadcn/ui patterns like @apply border-border and @apply bg-background text-foreground by converting them to actual CSS properties that work with the Tailwind CDN.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert common shadcn/ui @apply directives to real CSS in Sandpack so styles render correctly with the Tailwind CDN. Also strips @tailwind and unwraps @layer to prevent missing or duplicated styles.

- **Bug Fixes**
  - Remove @tailwind directives in CSS files (CDN handles these).
  - Unwrap @layer blocks and keep their content.
  - Translate @apply border-border, bg-background, and text-foreground to CSS variables:
    - border-color: hsl(var(--border))
    - background-color: hsl(var(--background))
    - color: hsl(var(--foreground))

<sup>Written for commit 1e8f4d6ba02d94b38adb7b4012a73084ced0cc98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

