### PR TITLE
fix: never filter out PiPilot DB tools from available tools

### DIFF
--- a/app/api/chat-v2/route.ts
+++ b/app/api/chat-v2/route.ts
@@ -10259,14 +10259,9 @@ ${fileAnalysis.filter(file => file.score < 70).map(file => `- **${file.name}**: 
         unavailableTools.push(...supabaseRemoteTools)
       }
 
-      // PiPilot database tools require databaseId
-      if (!databaseId) {
-        const dbTools = [
-          'create_table', 'query_database', 'manipulate_table_data', 'manage_api_keys',
-          'list_tables', 'read_table', 'delete_table'
-        ]
-        unavailableTools.push(...dbTools)
-      }
+      // PiPilot database tools are ALWAYS available - do NOT filter them out
+      // Even without a databaseId, the AI should be able to guide users to create a database first
+      // The tools will return helpful error messages if called without a valid database
 
       // node_machine requires E2B_API_KEY
       if (!process.env.E2B_API_KEY) {


### PR DESCRIPTION
PiPilot DB tools should always be available so the AI can guide users to create a database first, rather than hiding the tools entirely when no database exists yet.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep PiPilot database tools available even when no databaseId is set. This allows guiding users to create a database instead of hiding the tools; they return clear errors if invoked without a valid database.

<sup>Written for commit c2229d5131163821e938609cdb4ebbd4ae196863. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

