### PR TITLE
fix: remove deprecated experimental.appDir from Next.js template

### DIFF
--- a/lib/template-service.ts
+++ b/lib/template-service.ts
@@ -1725,9 +1725,6 @@ NODE_ENV=development`,
       path: 'next.config.js',
       content: `/** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   images: {
     domains: ['localhost','api.a0.dev'],
   },


### PR DESCRIPTION
The experimental.appDir config is no longer needed in Next.js 14+ since the App Router is now stable. Removes this to eliminate the warning.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the deprecated experimental.appDir from the Next.js template (next.config.js) now that the App Router is stable in Next.js 14+. This removes the build/runtime warning.

<sup>Written for commit ad6985a23c40acf67e1690e6b2c67a45beafe6df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

