### PR TITLE
fix: use pnpm instead of npm for console-feed installation

### DIFF
--- a/components/ai-elements/web-preview.tsx
+++ b/components/ai-elements/web-preview.tsx
@@ -672,8 +672,8 @@ export const WebPreviewConsole = ({
               <TabsTrigger value="browser" className="text-xs px-3 py-1 gap-1">
                 <Globe className="h-3 w-3" />
                 Browser
-                {parsedBrowserLogs.length > 0 && (
-                  <span className="ml-1 text-muted-foreground">({parsedBrowserLogs.length})</span>
+                {consoleFeedLogs.length > 0 && (
+                  <span className="ml-1 text-muted-foreground">({consoleFeedLogs.length})</span>
                 )}
               </TabsTrigger>
             </TabsList>


### PR DESCRIPTION
Remove npm-generated package-lock.json and update pnpm-lock.yaml to fix Vercel build error with frozen lockfile.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched console-feed installation to pnpm to fix Vercel frozen-lockfile build failures. Also fixed a Browser tab badge error by using the correct log source.

- **Bug Fixes**
  - Replaced parsedBrowserLogs with consoleFeedLogs in WebPreviewConsole to prevent an undefined variable error and show the correct count.

- **Dependencies**
  - Standardized installs to pnpm by removing package-lock.json and updating pnpm-lock.yaml to match the build setup.

<sup>Written for commit 2f246ad686c299937cc174f31c28e08367987c98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

