### PR TITLE
feat: update default AI model and add mistral/devstral-small-2

### DIFF
--- a/lib/ai-models.ts
+++ b/lib/ai-models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_CHAT_MODEL: string = 'xai/grok-code-fast-1';
+export const DEFAULT_CHAT_MODEL: string = 'mistral/devstral-2';
 
 export interface ChatModel {
   id: string;
@@ -45,6 +45,12 @@ export const chatModels: Array<ChatModel> = [
     id: 'mistral/devstral-2',
     name: 'Mistral Devstral 2',
     description: 'Mistral Devstral 2 via Vercel AI Gateway',
+    provider: 'vercel-gateway',
+  },
+  {
+    id: 'mistral/devstral-small-2',
+    name: 'Mistral Devstral Small 2',
+    description: 'Mistral Devstral Small 2 - Fast and efficient code generation',
     provider: 'vercel-gateway',
   },
   {


### PR DESCRIPTION
- Change DEFAULT_CHAT_MODEL from xai/grok-code-fast-1 to mistral/devstral-2
- Add mistral/devstral-small-2 model to available models list
- anthropic/claude-haiku-4.5 was already registered in both files

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the default chat model from xai/grok-code-fast-1 to mistral/devstral-2. Added mistral/devstral-small-2 to the model list as a fast, efficient option via the Vercel Gateway.

<sup>Written for commit 1885b3bb0389a88b8fc9068d526831d41c1ed62f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

