### PR TITLE
feat: update default AI model and add mistral/devstral-small-2

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -4127,9 +4127,9 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
       }
       const compressedData = await compressProjectFiles(projectFiles, fileTree, messagesToSend, metadata)
 
-      // For initial prompt, force use claude-haiku-4.5 model for UI prototyping
+      // For initial prompt, force use anthropic/claude-haiku-4.5 model for UI prototyping
       // Subsequent requests follow user/default model selection
-      const modelToUse = isInitialPrompt ? 'claude-haiku-4.5' : selectedModel
+      const modelToUse = isInitialPrompt ? 'anthropic/claude-haiku-4.5' : selectedModel
 
       console.log(`[ChatPanelV2] Using model: ${modelToUse} (${isInitialPrompt ? 'initial prompt override (UI prototyping)' : 'user selection'})`)
 

--- a/lib/ai-models.ts
+++ b/lib/ai-models.ts
@@ -84,6 +84,12 @@ export const chatModels: Array<ChatModel> = [
     provider: 'vercel-gateway',
   },
   {
+    id: 'zai/glm-4.7-flash',
+    name: 'ZAI GLM 4.7 Flash',
+    description: 'ZAI GLM 4.7 Flash - Fast inference via Vercel AI Gateway',
+    provider: 'vercel-gateway',
+  },
+  {
     id: 'minimax/minimax-m2.1',
     name: 'MiniMax M2.1',
     description: 'MiniMax M2.1 via Vercel AI Gateway',

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -291,6 +291,7 @@ const modelProviders: Record<string, any> = {
   'google/gemini-2.5-flash': vercelGateway('google/gemini-2.5-flash'),
   'google/gemini-2.5-pro': vercelGateway('google/gemini-2.5-pro'),
   'xai/glm-4.7': vercelGateway('xai/glm-4.7'),
+  'zai/glm-4.7-flash': vercelGateway('zai/glm-4.7-flash'),
   'minimax/minimax-m2.1': vercelGateway('minimax/minimax-m2.1'),
   'alibaba/qwen3-max': vercelGateway('alibaba/qwen3-max'),
   'openai/gpt-5.1-thinking': vercelGateway('openai/gpt-5.1-thinking'),


### PR DESCRIPTION
- Change DEFAULT_CHAT_MODEL from xai/grok-code-fast-1 to mistral/devstral-2
- Add mistral/devstral-small-2 model to available models list
- anthropic/claude-haiku-4.5 was already registered in both files

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ZAI GLM 4.7 Flash and fixes the initial prompt override to use the correct anthropic/claude-haiku-4.5 model, preventing “Model not found” errors.

- **New Features**
  - Added zai/glm-4.7-flash to the model list and provider map (Vercel AI Gateway).

- **Bug Fixes**
  - Corrected initial prompt override in Chat Panel to use anthropic/claude-haiku-4.5.

<sup>Written for commit 38d7dfc2809139452decd27a5240b06934daf558. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

