### PR TITLE
fix: add devstral-small-2 and glm-4.7-flash to model selector

### DIFF
--- a/components/ui/model-selector.tsx
+++ b/components/ui/model-selector.tsx
@@ -41,11 +41,13 @@ export function ModelSelector({
     ['auto', 'PiPilot Auto'],
     // Vercel AI Gateway Models
     ['mistral/devstral-2', 'PiPilot Mistral Devstral 2'],
+    ['mistral/devstral-small-2', 'PiPilot Mistral Devstral Small 2'],
     ['xai/grok-code-fast-1', 'PiPilot xAI Grok Code Fast 1'],
     ['moonshotai/kimi-k2-thinking', 'PiPilot MoonshotAI Kimi K2 Thinking'],
     ['google/gemini-2.5-flash', 'PiPilot Google Gemini 2.5 Flash'],
     ['google/gemini-2.5-pro', 'PiPilot Google Gemini 2.5 Pro'],
     ['xai/glm-4.7', 'PiPilot xAI GLM 4.7'],
+    ['zai/glm-4.7-flash', 'PiPilot ZAI GLM 4.7 Flash'],
     ['minimax/minimax-m2.1', 'PiPilot MiniMax M2.1'],
     ['alibaba/qwen3-max', 'PiPilot Alibaba Qwen3 Max'],
     ['anthropic/claude-haiku-4.5', 'PiPilot Anthropic Claude Haiku 4.5'],
@@ -76,7 +78,9 @@ export function ModelSelector({
     allowedModels = [
       'xai/grok-code-fast-1',
       'mistral/devstral-2',
+      'mistral/devstral-small-2',
       'google/gemini-2.5-flash',
+      'zai/glm-4.7-flash',
       'anthropic/claude-sonnet-4.5'
     ];
   } else if (isPremium && effectiveStatus === 'active') {
@@ -84,8 +88,10 @@ export function ModelSelector({
     allowedModels = [
       // Free models (premium users get access to everything)
       'mistral/devstral-2',
+      'mistral/devstral-small-2',
       'xai/grok-code-fast-1',
       'google/gemini-2.5-flash',
+      'zai/glm-4.7-flash',
       // Premium models
       'auto',
       'moonshotai/kimi-k2-thinking',


### PR DESCRIPTION
The new models were added to lib/ai-models.ts but were not showing in the UI because they were missing from the displayNameMap and allowedModels arrays in the model selector component.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed missing models in the model selector so new backend additions show in the UI. Added mistral/devstral-small-2 and zai/glm-4.7-flash to the display name map and to allowedModels for both free and premium plans.

<sup>Written for commit be7e93c1d6930039aa5c521980c691643ca90c48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

