### PR TITLE
fix: use Anthropic provider for Devstral models with images

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -272,6 +272,13 @@ const modelProviders: Record<string, any> = {
   'anthropic/claude-opus-4.5': anthropicProvider('anthropic/claude-opus-4.5'),
 };
 
+// Models that support vision through Anthropic provider format (for image handling)
+// These models use the Anthropic SDK format when images are attached
+const visionViaAnthropicModels: Record<string, string> = {
+  'mistral/devstral-2': 'mistral/devstral-2',
+  'mistral/devstral-small-2': 'mistral/devstral-small-2',
+};
+
 // Helper function to get a model by ID
 export function getModel(modelId: string) {
   const model = modelProviders[modelId];
@@ -279,6 +286,25 @@ export function getModel(modelId: string) {
     throw new Error(`Model ${modelId} not found. Available models: ${Object.keys(modelProviders).join(', ')}`);
   }
   return model;
+}
+
+// Helper function to get model with vision support
+// For Devstral models with images, returns Anthropic provider which handles images correctly via gateway
+export function getModelWithVision(modelId: string, hasImages: boolean = false) {
+  // If no images or model doesn't need special handling, use default
+  if (!hasImages || !visionViaAnthropicModels[modelId]) {
+    return getModel(modelId);
+  }
+
+  // For Devstral with images, use Anthropic provider through gateway
+  // This sends images in Anthropic format which the gateway handles correctly
+  console.log(`[AI Providers] Using Anthropic provider for ${modelId} with images (gateway routing)`);
+  return anthropicProvider(visionViaAnthropicModels[modelId]);
+}
+
+// Check if a model requires Anthropic format for images
+export function requiresAnthropicImageFormat(modelId: string): boolean {
+  return !!visionViaAnthropicModels[modelId];
 }
 
 // Export individual providers for direct use if needed


### PR DESCRIPTION
- Add getModelWithVision() and requiresAnthropicImageFormat() helpers
- For Devstral with images, use Anthropic provider via gateway
- Convert images to Anthropic format (source object) for Devstral
- This matches how agent-cloud handles vision through the gateway
- Move model initialization after image detection

The key fix: Devstral doesn't support images through OpenAI-compatible format, but does work with Anthropic format through Vercel AI Gateway.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes vision requests for Devstral models by routing image chats through the Anthropic provider via Vercel AI Gateway and converting images to Anthropic format. Prevents errors when users send images to Devstral.

- **Bug Fixes**
  - Detect images and switch Devstral to Anthropic provider; convert images to Anthropic source format.
  - Keep OpenAI-style image_url for other providers; non-image flows unchanged.
  - Add getModelWithVision and requiresAnthropicImageFormat; initialize model after image detection.
  - Apply ephemeral cache control when using Anthropic provider; reasoning options only for true Anthropic (Claude) models.

<sup>Written for commit 96f90a5af94d720336bc0f1a03f982451781b141. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

