### PR TITLE
fix: use Anthropic provider for Devstral models with images

### DIFF
--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -155,6 +155,12 @@ const mistralProvider = createMistral({
   apiKey: process.env.MISTRAL_API_KEY || 'W8txIqwcJnyHBTthSlouN2w3mQciqAUr',
 });
 
+// Create Mistral provider with Vercel AI Gateway (for vision support)
+const mistralGatewayProvider = createMistral({
+  baseURL: 'https://ai-gateway.vercel.sh/v1',
+  apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY || '',
+});
+
 const xaiProvider = createXai({
   apiKey: process.env.XAI_API_KEY || 'xai-your-api-key-here',
 });
@@ -293,14 +299,14 @@ export function needsMistralVisionProvider(modelId: string): boolean {
   return !!devstralVisionModels[modelId];
 }
 
-// Get the vision-capable model for Devstral (uses Mistral provider with correct model name)
+// Get the vision-capable model for Devstral (uses Mistral Gateway provider with correct model name)
 export function getDevstralVisionModel(modelId: string) {
   const mistralModelName = devstralVisionModels[modelId];
   if (!mistralModelName) {
     throw new Error(`Model ${modelId} is not a Devstral vision model`);
   }
-  console.log(`[AI Providers] Using Mistral provider for ${modelId} -> ${mistralModelName} (vision support)`);
-  return mistralProvider(mistralModelName);
+  console.log(`[AI Providers] Using Mistral Gateway provider for ${modelId} -> ${mistralModelName} (vision support)`);
+  return mistralGatewayProvider(mistralModelName);
 }
 
 // Export individual providers for direct use if needed


### PR DESCRIPTION
The vercelGateway (OpenAI-compatible) doesn't properly handle image conversion for Mistral models. Now using the @ai-sdk/mistral provider with correct Mistral API model names when images are present:

- mistral/devstral-2 -> devstral-2512
- mistral/devstral-small-2 -> labs-devstral-small-2512

The Mistral provider properly converts Vercel AI SDK image format to Mistral's expected format internally.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image handling for Devstral vision models by routing them through the Mistral provider via the Vercel Gateway and using the correct Mistral model IDs. This prevents failures from the OpenAI-compatible gateway that didn’t convert images properly.

- **Bug Fixes**
  - Use Mistral provider through Vercel Gateway for image-enabled Devstral models.
  - Map model IDs: mistral/devstral-2 → devstral-2512; mistral/devstral-small-2 → labs-devstral-small-2512.

- **Migration**
  - Set VERCEL_GATEWAY_API_KEY (VERCEL_AI_GATEWAY_API_KEY in env) for gateway access.

<sup>Written for commit f21da0de2c0dc128d31d9ad906b526944fb11e98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

