### PR TITLE
fix: prevent double message submit and fix disabled state for image a…

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5677,8 +5677,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                 type="submit"
                 size="icon"
                 className="h-8 w-8"
-                disabled={!input.trim() && attachedFiles.length === 0}
-                onClick={handleEnhancedSubmit}
+                disabled={!input.trim() && attachedFiles.length === 0 && attachedImages.length === 0}
               >
                 <CornerDownLeft className="size-4" />
               </Button>


### PR DESCRIPTION
…ttachments

- Removed redundant onClick handler from send button (form onSubmit already handles it)
- Added attachedImages.length check to disabled condition

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double message sends and correctly enables the send button when only images are attached. Improves reliability for image-only messages.

- **Bug Fixes**
  - Removed send button onClick; submit is handled by form onSubmit.
  - Disabled state now checks attachedImages, not just text and files.

<sup>Written for commit 877028abf770fae81d771d57912008771ff4a88b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

