### PR TITLE
fix: switch describe-image API to gateway model to avoid 429 rate limits

### DIFF
--- a/app/api/describe-image/route.ts
+++ b/app/api/describe-image/route.ts
@@ -1,10 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { generateText } from 'ai'
-import { createMistral } from '@ai-sdk/mistral'
-
-const mistral = createMistral({
-  apiKey: process.env.MISTRAL_API_KEY || 'W8txIqwcJnyHBTthSlouN2w3mQciqAUr',
-})
+import { vercelGateway } from '@/lib/ai-providers'
 
 // =============================================================================
 // MODE: CLONE - Structured JSON for UI cloning/recreation
@@ -274,9 +270,9 @@ export async function POST(request: NextRequest) {
       systemPrompt = prompt
     }
 
-    // Use Pixtral (Mistral's vision model) for image analysis
+    // Use Mistral vision model via Vercel AI Gateway to avoid rate limits
     const result = await generateText({
-      model: mistral('pixtral-12b-2409'),
+      model: vercelGateway('mistral/devstral-small-2'),
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
- Changed from direct Mistral API (pixtral-12b-2409) to Vercel AI Gateway (mistral/devstral-small-2)
- Cleaned up test-vision page to use describe-image API directly
- Added mode selection UI (clone/debug/context) to test page

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the describe-image API to the Vercel AI Gateway (mistral/devstral-small-2) to prevent 429 rate limits. Updated the test-vision page to use this API with a simpler mode-based UI.

- **Bug Fixes**
  - Route now uses the Gateway model instead of direct Pixtral, reducing rate limit errors.
  - Improved error handling: API returns structured JSON; client surfaces clear messages.

- **New Features**
  - Added mode selection (clone, debug, context) with tailored outputs.
  - Test page calls /api/describe-image directly and shows JSON or text results without SSE streaming.

<sup>Written for commit c0c9bf7f7f1a2ede268e35f099ea021d168a86ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

