### PR TITLE
fix: send button click not working in chat panel

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5849,10 +5849,11 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
             ) : (
               <Button
                 ref={sendButtonRef}
-                type="submit"
+                type="button"
                 size="icon"
                 className="h-8 w-8"
                 disabled={(!input.trim() && attachedFiles.length === 0 && attachedImages.length === 0) || attachedImages.some((img: AttachedImage) => img.isProcessing)}
+                onClick={handleEnhancedSubmit}
               >
                 <CornerDownLeft className="size-4" />
               </Button>


### PR DESCRIPTION
The send button was outside the <form> element, so type="submit" had no effect. Changed to type="button" with onClick={handleEnhancedSubmit} to trigger form submission when clicked.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat panel send button so clicks submit the message. The button was outside the form, so type=submit did nothing; it’s now type=button with onClick={handleEnhancedSubmit} to trigger submission.

<sup>Written for commit 0f7fbabe4d65032f612d47d0d60e0202c772b617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

