### PR TITLE
fix: remove duplicate data URL prefix from image previews in chat

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -253,10 +253,10 @@ const ExpandableUserMessage = ({
                   {images.map((img) => (
                     <img
                       key={img.id}
-                      src={`data:image/png;base64,${img.base64}`}
+                      src={img.base64}
                       alt={img.name}
                       className="max-w-[120px] max-h-[90px] rounded-lg object-cover cursor-pointer hover:opacity-80 transition-opacity border border-border"
-                      onClick={() => setPreviewImage(`data:image/png;base64,${img.base64}`)}
+                      onClick={() => setPreviewImage(img.base64)}
                       title={img.name}
                     />
                   ))}
@@ -323,10 +323,10 @@ const ExpandableUserMessage = ({
               {images.map((img) => (
                 <img
                   key={img.id}
-                  src={`data:image/png;base64,${img.base64}`}
+                  src={img.base64}
                   alt={img.name}
                   className="max-w-[120px] max-h-[90px] rounded-lg object-cover cursor-pointer hover:opacity-80 transition-opacity border border-border"
-                  onClick={() => setPreviewImage(`data:image/png;base64,${img.base64}`)}
+                  onClick={() => setPreviewImage(img.base64)}
                   title={img.name}
                 />
               ))}


### PR DESCRIPTION
The img.base64 field already contains the complete data URL (e.g., data:image/png;base64,...), so prepending the prefix again was causing corrupted/broken image previews.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed broken chat image thumbnails and previews by using the full data URL from img.base64 without re-adding the data:image/png;base64, prefix. Thumbnails now render correctly and the preview opens as expected.

<sup>Written for commit 27dcfc43eacdfa265befe37809df7339780f6230. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

