### PR TITLE
feat: add model selector and chat session dropdown to preview tab header

### DIFF
--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -54,10 +54,12 @@ import {
   DEVICE_PRESETS
 } from "@/components/ai-elements/web-preview";
 import { DatabaseTab } from "./database-tab";
-import { 
+import {
   VisualEditorWrapper,
   VisualEditorToggle,
 } from "./visual-editor-wrapper";
+import { ModelSelector } from "@/components/ui/model-selector";
+import { ChatSessionSelector } from "@/components/ui/chat-session-selector";
 import type { StyleChange, Theme } from "@/lib/visual-editor";
 import dynamic from "next/dynamic";
 
@@ -132,6 +134,16 @@ interface CodePreviewPanelProps {
   onTagToChat?: (component: { id: string; tagName: string; sourceFile?: string; sourceLine?: number; className: string; textContent?: string }) => void;
   onPublish?: () => void;
   isAIStreaming?: boolean;
+  // Model selector props
+  selectedModel?: string;
+  onModelChange?: (model: string) => void;
+  userPlan?: string;
+  subscriptionStatus?: string;
+  // Chat session selector props
+  userId?: string;
+  currentSessionId?: string | null;
+  onSessionChange?: (sessionId: string) => void;
+  onNewSession?: () => void;
 }
 
 export interface CodePreviewPanelRef {
@@ -861,7 +873,7 @@ function PreviewEmptyState({ projectName, onStartPreview, disabled }: {
 }
 
 export const CodePreviewPanel = forwardRef<CodePreviewPanelRef, CodePreviewPanelProps>(
-  ({ project, activeTab, onTabChange, previewViewMode = "desktop", syncedUrl, onUrlChange, onVisualEditorSave, onApplyTheme, onTagToChat, onPublish, isAIStreaming = false }, ref) => {
+  ({ project, activeTab, onTabChange, previewViewMode = "desktop", syncedUrl, onUrlChange, onVisualEditorSave, onApplyTheme, onTagToChat, onPublish, isAIStreaming = false, selectedModel, onModelChange, userPlan, subscriptionStatus, userId, currentSessionId, onSessionChange, onNewSession }, ref) => {
     const { toast } = useToast();
     const isMobile = useIsMobile();
     const [preview, setPreview] = useState<PreviewState>({
@@ -2888,8 +2900,31 @@ export default function TodoApp() {
             }}
           >
             <WebPreviewNavigation className="fixed top-0 left-0 right-0 z-50 bg-card border-b border-border">
+              {/* Model Selector and Chat Session Selector */}
+              {project && selectedModel && onModelChange && (
+                <div className="flex items-center gap-1 ml-2">
+                  <ModelSelector
+                    selectedModel={selectedModel}
+                    onModelChange={onModelChange}
+                    userPlan={userPlan}
+                    subscriptionStatus={subscriptionStatus}
+                    compact={true}
+                  />
+                  {userId && onSessionChange && (
+                    <ChatSessionSelector
+                      workspaceId={project.id}
+                      userId={userId}
+                      currentSessionId={currentSessionId || null}
+                      onSessionChange={onSessionChange}
+                      onNewSession={onNewSession}
+                      compact={true}
+                    />
+                  )}
+                </div>
+              )}
+
               <div className="flex-1" />
-              
+
               {/* Tab switching buttons */}
               <WebPreviewNavigationButton
                 onClick={() => onTabChange("code")}

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -1136,11 +1136,11 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                       </ResizablePanelGroup>
                     ) : activeTab === "preview" ? (
                       /* Preview Tab: Full-width Preview */
-                      <CodePreviewPanel 
-                        ref={codePreviewRef} 
-                        project={selectedProject} 
-                        activeTab={activeTab} 
-                        onTabChange={setActiveTab} 
+                      <CodePreviewPanel
+                        ref={codePreviewRef}
+                        project={selectedProject}
+                        activeTab={activeTab}
+                        onTabChange={setActiveTab}
                         previewViewMode={previewViewMode}
                         syncedUrl={syncedPreview.url || customUrl}
                         onUrlChange={setCustomUrl}
@@ -1158,6 +1158,19 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                           codePreviewRef.current?.createPreview()
                         }}
                         isAIStreaming={isAIStreaming}
+                        selectedModel={selectedModel}
+                        onModelChange={setSelectedModel}
+                        userPlan={userPlan}
+                        subscriptionStatus={subscriptionStatus}
+                        userId={user.id}
+                        currentSessionId={currentChatSessionId}
+                        onSessionChange={(sessionId) => {
+                          setCurrentChatSessionId(sessionId)
+                          setChatSessionKey(prev => prev + 1)
+                        }}
+                        onNewSession={() => {
+                          setChatSessionKey(prev => prev + 1)
+                        }}
                       />
                     ) : activeTab === "cloud" ? (
                       /* Cloud Tab */
@@ -1634,6 +1647,19 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                       onVisualEditorSave={handleVisualEditorSave}
                       onApplyTheme={handleVisualEditorThemeSave}
                       isAIStreaming={isAIStreaming}
+                      selectedModel={selectedModel}
+                      onModelChange={setSelectedModel}
+                      userPlan={userPlan}
+                      subscriptionStatus={subscriptionStatus}
+                      userId={user.id}
+                      currentSessionId={currentChatSessionId}
+                      onSessionChange={(sessionId) => {
+                        setCurrentChatSessionId(sessionId)
+                        setChatSessionKey(prev => prev + 1)
+                      }}
+                      onNewSession={() => {
+                        setChatSessionKey(prev => prev + 1)
+                      }}
                     />
                   </div>
                 </TabsContent>


### PR DESCRIPTION
Added ModelSelector and ChatSessionSelector components to the preview tab header so users can switch chat sessions and select models while viewing the preview tab without needing to switch back to code view.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add model and chat session controls to the Preview tab header so you can switch models and sessions without leaving Preview. This streamlines testing and iteration in the preview view.

- **New Features**
  - Added compact ModelSelector in the preview header; respects plan/subscription.
  - Added ChatSessionSelector (when user is present) to switch or start sessions.
  - Wired state in WorkspaceLayout: passes model, plan, subscription, user, and session; updates session key on change.
  - Extended CodePreviewPanel with optional props for these controls. No breaking changes.

<sup>Written for commit 7f175340c6bc1d579bfe12eb83e0f022a97fd109. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

