### PR TITLE
fix: prevent horizontal overflow from long links in AI reasoning and …

### DIFF
--- a/app/agent-cloud/session/page.tsx
+++ b/app/agent-cloud/session/page.tsx
@@ -1297,7 +1297,7 @@ User Request: ${currentPrompt}`
                 </div>
               )}
               {line.content && (
-                <p className="text-zinc-100 text-sm leading-relaxed whitespace-pre-wrap">{displayContent}</p>
+                <p className="text-zinc-100 text-sm leading-relaxed whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{displayContent}</p>
               )}
               {isLong && (
                 <button
@@ -1330,9 +1330,9 @@ User Request: ${currentPrompt}`
             <div className="h-7 w-7 rounded-full bg-gradient-to-br from-orange-500 to-amber-600 flex items-center justify-center shrink-0">
               <Bot className="h-4 w-4 text-white" />
             </div>
-            <div className="flex-1 min-w-0 pt-0.5">
+            <div className="flex-1 min-w-0 pt-0.5 overflow-hidden">
               <div className="relative">
-                <div className="prose prose-invert prose-sm max-w-none">
+                <div className="prose prose-invert prose-sm max-w-none break-words [overflow-wrap:anywhere] prose-a:break-all prose-pre:overflow-x-auto">
                   <Response className="text-zinc-300">
                     {line.content}
                   </Response>
@@ -1358,7 +1358,7 @@ User Request: ${currentPrompt}`
             <div className="h-7 w-7 rounded-full bg-red-500/20 flex items-center justify-center shrink-0">
               <span className="text-xs text-red-400 font-bold">!</span>
             </div>
-            <div className="flex-1 text-red-400 text-sm bg-red-500/10 rounded-lg px-3 py-2 font-mono">
+            <div className="flex-1 text-red-400 text-sm bg-red-500/10 rounded-lg px-3 py-2 font-mono break-words [overflow-wrap:anywhere]">
               {line.content}
             </div>
           </div>
@@ -1413,7 +1413,7 @@ User Request: ${currentPrompt}`
             >
               {/* Tool header */}
               <div
-                className={`flex items-center gap-2 px-3 py-2 ${hasExpandableContent ? 'cursor-pointer hover:bg-zinc-800/30' : ''}`}
+                className={`flex items-center gap-2 px-3 py-2 min-w-0 ${hasExpandableContent ? 'cursor-pointer hover:bg-zinc-800/30' : ''}`}
                 onClick={() => hasExpandableContent && toggleToolExpanded(index)}
               >
                 {/* Expand/collapse icon */}
@@ -1428,13 +1428,13 @@ User Request: ${currentPrompt}`
                 )}
 
                 {/* Tool badge */}
-                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium border ${getToolColor()}`}>
+                <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium border shrink-0 ${getToolColor()}`}>
                   {getToolIcon()}
                   {toolName}
                 </span>
 
                 {/* Description */}
-                <span className="text-xs text-zinc-400 truncate flex-1 font-mono">
+                <span className="text-xs text-zinc-400 truncate flex-1 font-mono min-w-0">
                   {meta.fileName || meta.description || line.content}
                 </span>
 
@@ -1446,21 +1446,21 @@ User Request: ${currentPrompt}`
 
               {/* Expanded content */}
               {isExpanded && hasExpandableContent && (
-                <div className="border-t border-zinc-800/80">
+                <div className="border-t border-zinc-800/80 overflow-hidden">
                   {/* Bash: Show command and output */}
                   {toolName === 'Bash' && (
-                    <div className="text-xs font-mono">
+                    <div className="text-xs font-mono overflow-hidden">
                       {meta.command && (
-                        <div className="px-3 py-2 bg-zinc-950/50 border-b border-zinc-800/50">
-                          <div className="flex items-center gap-1.5 text-emerald-400/80 mb-1">
-                            <span className="text-zinc-500">$</span>
-                            <span className="break-all whitespace-pre-wrap">{meta.command}</span>
+                        <div className="px-3 py-2 bg-zinc-950/50 border-b border-zinc-800/50 overflow-hidden">
+                          <div className="flex items-start gap-1.5 text-emerald-400/80 mb-1">
+                            <span className="text-zinc-500 shrink-0">$</span>
+                            <span className="break-all whitespace-pre-wrap [overflow-wrap:anywhere]">{meta.command}</span>
                           </div>
                         </div>
                       )}
                       {meta.result && (
-                        <div className="px-3 py-2 text-zinc-400 max-h-60 overflow-y-auto">
-                          <pre className="whitespace-pre-wrap break-all text-[11px] leading-4">{meta.result}</pre>
+                        <div className="px-3 py-2 text-zinc-400 max-h-60 overflow-y-auto overflow-x-hidden">
+                          <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-[11px] leading-4">{meta.result}</pre>
                         </div>
                       )}
                     </div>
@@ -1468,27 +1468,27 @@ User Request: ${currentPrompt}`
 
                   {/* Edit: Show diff */}
                   {toolName === 'Edit' && (meta.oldString || meta.newString) && (
-                    <div className="text-xs font-mono">
+                    <div className="text-xs font-mono overflow-hidden">
                       {meta.oldString && (
-                        <div className="px-3 py-2 bg-red-500/5 border-b border-zinc-800/50">
+                        <div className="px-3 py-2 bg-red-500/5 border-b border-zinc-800/50 overflow-hidden">
                           <div className="flex items-center gap-1.5 mb-1">
-                            <Minus className="h-3 w-3 text-red-400" />
+                            <Minus className="h-3 w-3 text-red-400 shrink-0" />
                             <span className="text-red-400/70 text-[10px]">old</span>
                           </div>
-                          <pre className="whitespace-pre-wrap break-all text-red-300/70 text-[11px] leading-4 pl-4 max-h-40 overflow-y-auto">{meta.oldString}</pre>
+                          <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-red-300/70 text-[11px] leading-4 pl-4 max-h-40 overflow-y-auto overflow-x-hidden">{meta.oldString}</pre>
                         </div>
                       )}
                       {meta.newString && (
-                        <div className="px-3 py-2 bg-emerald-500/5">
+                        <div className="px-3 py-2 bg-emerald-500/5 overflow-hidden">
                           <div className="flex items-center gap-1.5 mb-1">
-                            <Plus className="h-3 w-3 text-emerald-400" />
+                            <Plus className="h-3 w-3 text-emerald-400 shrink-0" />
                             <span className="text-emerald-400/70 text-[10px]">new</span>
                           </div>
-                          <pre className="whitespace-pre-wrap break-all text-emerald-300/70 text-[11px] leading-4 pl-4 max-h-40 overflow-y-auto">{meta.newString}</pre>
+                          <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-emerald-300/70 text-[11px] leading-4 pl-4 max-h-40 overflow-y-auto overflow-x-hidden">{meta.newString}</pre>
                         </div>
                       )}
                       {meta.result && (
-                        <div className="px-3 py-1.5 text-zinc-500 text-[10px] border-t border-zinc-800/50">
+                        <div className="px-3 py-1.5 text-zinc-500 text-[10px] border-t border-zinc-800/50 break-words">
                           {meta.result.includes('successfully') ? '✓ Applied' : meta.result.substring(0, 100)}
                         </div>
                       )}
@@ -1497,36 +1497,36 @@ User Request: ${currentPrompt}`
 
                   {/* Write: Show file content preview */}
                   {toolName === 'Write' && meta.fileContent && (
-                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-60 overflow-y-auto">
-                      <pre className="whitespace-pre-wrap break-all text-zinc-400 text-[11px] leading-4">{meta.fileContent}{meta.fileContent.length >= 500 ? '\n...' : ''}</pre>
+                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-60 overflow-y-auto overflow-x-hidden">
+                      <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-zinc-400 text-[11px] leading-4">{meta.fileContent}{meta.fileContent.length >= 500 ? '\n...' : ''}</pre>
                     </div>
                   )}
 
                   {/* Read: Show result */}
                   {toolName === 'Read' && meta.result && (
-                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-60 overflow-y-auto">
-                      <pre className="whitespace-pre-wrap break-all text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
+                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-60 overflow-y-auto overflow-x-hidden">
+                      <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
                     </div>
                   )}
 
                   {/* Glob/Grep: Show results */}
                   {(toolName === 'Glob' || toolName === 'Grep') && meta.result && (
-                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-48 overflow-y-auto">
-                      <pre className="whitespace-pre-wrap break-all text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
+                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-48 overflow-y-auto overflow-x-hidden">
+                      <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
                     </div>
                   )}
 
                   {/* WebSearch/WebFetch: Show results */}
                   {(toolName === 'WebSearch' || toolName === 'WebFetch') && meta.result && (
-                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-48 overflow-y-auto">
-                      <pre className="whitespace-pre-wrap break-all text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
+                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-48 overflow-y-auto overflow-x-hidden">
+                      <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
                     </div>
                   )}
 
                   {/* Generic: Show result for any other tool with a result */}
                   {!['Bash', 'Edit', 'Write', 'Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch'].includes(toolName) && meta.result && (
-                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-48 overflow-y-auto">
-                      <pre className="whitespace-pre-wrap break-all text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
+                    <div className="text-xs font-mono px-3 py-2 bg-zinc-950/50 max-h-48 overflow-y-auto overflow-x-hidden">
+                      <pre className="whitespace-pre-wrap break-all [overflow-wrap:anywhere] text-zinc-400 text-[11px] leading-4">{meta.result}</pre>
                     </div>
                   )}
                 </div>

--- a/components/ai-elements/chain-of-thought.tsx
+++ b/components/ai-elements/chain-of-thought.tsx
@@ -65,7 +65,7 @@ export const ChainOfThought = memo(
     return (
       <ChainOfThoughtContext.Provider value={chainOfThoughtContext}>
         <div
-          className={cn("not-prose max-w-prose space-y-4", className)}
+          className={cn("not-prose max-w-prose space-y-4 overflow-hidden", className)}
           {...props}
         >
           {children}
@@ -145,12 +145,12 @@ export const ChainOfThoughtStep = memo(
           <Icon className="size-4" />
           <div className="-mx-px absolute top-7 bottom-0 left-1/2 w-px bg-border" />
         </div>
-        <div className="flex-1 space-y-2">
-          <div>{label}</div>
+        <div className="flex-1 space-y-2 min-w-0 overflow-hidden">
+          <div className="break-words">{label}</div>
           {description && (
-            <div className="text-muted-foreground text-xs">{description}</div>
+            <div className="text-muted-foreground text-xs break-words">{description}</div>
           )}
-          {children}
+          <div className="break-words overflow-wrap-anywhere">{children}</div>
         </div>
       </div>
     );
@@ -191,7 +191,7 @@ export const ChainOfThoughtContent = memo(
       <Collapsible open={isOpen}>
         <CollapsibleContent
           className={cn(
-            "mt-2 space-y-3",
+            "mt-2 space-y-3 overflow-hidden",
             "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in",
             className
           )}

--- a/components/workspace/message-with-tools.tsx
+++ b/components/workspace/message-with-tools.tsx
@@ -542,13 +542,15 @@ export function MessageWithTools({ message, projectId, isStreaming = false, onCo
               >
                 <div className={cn(
                   'prose prose-sm dark:prose-invert max-w-none mt-2',
-                  'prose-pre:bg-muted prose-pre:text-foreground',
+                  'prose-pre:bg-muted prose-pre:text-foreground prose-pre:overflow-x-auto',
                   'prose-code:text-foreground prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded',
-                  'prose-p:text-muted-foreground',
+                  'prose-p:text-muted-foreground prose-p:break-words',
                   'prose-headings:text-foreground',
                   'prose-strong:text-foreground',
                   'prose-ul:text-muted-foreground',
-                  'prose-ol:text-muted-foreground'
+                  'prose-ol:text-muted-foreground',
+                  'prose-a:break-all',
+                  'overflow-hidden break-words [overflow-wrap:anywhere]'
                 )}>
                   {inlineToolCalls && inlineToolCalls.length > 0 ? (
                     <InterleavedContent
@@ -602,8 +604,10 @@ export function MessageWithTools({ message, projectId, isStreaming = false, onCo
       {hasResponse && (
         <div className={cn(
           'prose prose-sm dark:prose-invert max-w-none',
-          'prose-pre:bg-muted prose-pre:text-foreground',
-          'prose-code:text-foreground prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded'
+          'prose-pre:bg-muted prose-pre:text-foreground prose-pre:overflow-x-auto',
+          'prose-code:text-foreground prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded',
+          'prose-a:break-all',
+          'overflow-hidden break-words [overflow-wrap:anywhere]'
         )}>
           {(() => {
             // Filter out tools that were called during reasoning (not during text streaming)


### PR DESCRIPTION
…messages

Added overflow handling and word-breaking CSS to:
- ChainOfThought component and its child elements
- MessageWithTools reasoning content and response sections
- Agent-cloud session page user/assistant messages and tool result panels

This ensures long URLs and content respect their container widths.

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented horizontal overflow from long URLs and unbroken text in reasoning and message views. Content now wraps or scrolls within its container to avoid layout breakage.

- **Bug Fixes**
  - Applied word-breaking and overflow handling to ChainOfThought, MessageWithTools, and agent-cloud session messages and tool panels.
  - Enabled horizontal scroll for code/pre blocks; long links and text wrap instead of expanding the layout.

<sup>Written for commit 226b7a1cae7f004ecb42f80ef1cec74194bf54a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

