### PR TITLE
fix: prevent vertical overflow in workspace during AI streaming

### DIFF
--- a/components/ai-elements/response.tsx
+++ b/components/ai-elements/response.tsx
@@ -10,7 +10,7 @@ export const Response = memo(
   ({ className, ...props }: ResponseProps) => (
     <Streamdown
       className={cn(
-        "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 break-words overflow-wrap-anywhere",
+        "w-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 break-words overflow-wrap-anywhere",
         // Enhanced spacing and readability for reasoning content
         "leading-relaxed", // Relaxed line height for better readability
         "[&>p]:mb-4 [&>p]:last:mb-0", // Paragraph spacing

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col min-h-0 gap-6 rounded-xl border py-6 shadow-sm",
         className
       )}
       {...props}


### PR DESCRIPTION
- Changed Response component from size-full to w-full to allow content to flow naturally instead of trying to match parent height
- Added min-h-0 to Card flex-col to properly constrain flexbox height calculations and prevent unbounded expansion during streaming

https://claude.ai/code/session_01WLE22WukzHerKY3KSQxcpx