### PR TITLE
fix: add overflow containment to right panel and status bar in workspace

### DIFF
--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -1043,7 +1043,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
                 {/* Right Panel - Code/Preview Area */}
                 <ResizablePanel defaultSize={60} minSize={30}>
-                  <div className="h-full flex flex-col">
+                  <div className="h-full flex flex-col overflow-hidden">
                     {/* Tab Switcher with Preview Controls - Hidden when in preview mode */}
                     {activeTab !== "preview" && (
                       <div className="border-b border-border bg-card p-2 flex-shrink-0">
@@ -1237,7 +1237,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
             {/* Status Bar */}
             {selectedProject && (
-              <div className="h-8 border-t border-border bg-muted/50 flex items-center justify-between px-4 text-xs">
+              <div className="h-8 flex-shrink-0 border-t border-border bg-muted/50 flex items-center justify-between px-4 text-xs">
                 <div className="flex items-center space-x-4">
                   {/* GitHub Status */}
                   <div className="flex items-center space-x-1">


### PR DESCRIPTION
- Add overflow-hidden to right panel (code/preview) container to prevent file explorer and editor content from pushing layout bounds
- Add flex-shrink-0 to status bar to keep it fixed at h-8 and prevent it from being squeezed off-screen by overflowing content above

The right panel was the remaining leak point: chat content overflow cascaded through ResizablePanelGroup into the right panel, causing the full-page vertical scrollbar visible on the extreme right.

https://claude.ai/code/session_01HRFpspUJZFNtUFasgeV1cT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops layout overflow in the workspace by containing the right panel and fixing the status bar height, removing the extra full-page scrollbar.

- **Bug Fixes**
  - Right panel (code/preview): added overflow-hidden to prevent explorer/editor content from pushing layout bounds and causing a page scrollbar.
  - Status bar: added flex-shrink-0 to keep it at h-8 and prevent it from being squeezed off-screen.

<sup>Written for commit 16f604e094fb81f4068b1af298d996d2f47c8c10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

