### PR TITLE
fix: remove excessive overflow-hidden that was hiding workspace content

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5154,7 +5154,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
   }
 
   return (
-    <div className={`flex flex-col overflow-hidden ${isMobile ? 'h-[calc(100vh-9.5rem)]' : 'h-full'}`}>
+    <div className={`flex flex-col ${isMobile ? 'h-[calc(100vh-9.5rem)]' : 'h-full'}`}>
       {/* Messages Area - Scrollable container */}
       <div className={`flex-1 min-h-0 overflow-y-auto space-y-4 ${isMobile ? 'p-4 pb-20' : 'p-4'}`}>
         {messages.length === 0 && (
@@ -5167,7 +5167,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
           <div
             key={message.id}
             className={cn(
-              'flex min-h-0',
+              'flex',
               message.role === 'user' ? 'justify-end' : 'justify-start'
             )}
           >

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -924,7 +924,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
           />
 
           {/* Main Content */}
-          <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
+          <div className="flex-1 flex flex-col min-w-0 min-h-0">
             {/* Project Header */}
             <ProjectHeader
               project={selectedProject}
@@ -1026,7 +1026,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
               <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
                 {/* Left Panel - Chat (Resizable) */}
                 <ResizablePanel defaultSize={40} minSize={20} maxSize={40}>
-                  <div className="h-full flex flex-col overflow-hidden border-r border-border">
+                  <div className="h-full flex flex-col border-r border-border">
                     <ChatPanelV2
                       key={`chat-${selectedProject.id}-${chatSessionKey}`}
                       project={selectedProject}
@@ -1043,7 +1043,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
                 {/* Right Panel - Code/Preview Area */}
                 <ResizablePanel defaultSize={60} minSize={30}>
-                  <div className="h-full flex flex-col overflow-hidden">
+                  <div className="h-full flex flex-col">
                     {/* Tab Switcher with Preview Controls - Hidden when in preview mode */}
                     {activeTab !== "preview" && (
                       <div className="border-b border-border bg-card p-2 flex-shrink-0">
@@ -1316,7 +1316,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
       {/* Mobile Layout */}
       {isMobile && (
-        <div className="h-full w-full flex flex-col overflow-hidden">
+        <div className="h-full w-full flex flex-col">
           {/* Always use ModernSidebar for mobile */}
           <ModernSidebar
             user={user}


### PR DESCRIPTION
Revert overflow-hidden from intermediate containers (chat wrapper, right panel, mobile layout, ChatPanelV2 root, main content wrapper) that was clipping content and making messages/editor invisible.

Keep overflow-hidden only on the root h-screen container which is sufficient to prevent the page-level vertical scrollbar. Also revert min-h-0 from message wrappers as it's unnecessary for scroll children.

https://claude.ai/code/session_01HRFpspUJZFNtUFasgeV1cT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed extra overflow-hidden from workspace containers to stop clipping that hid chat messages and the editor. Kept overflow control only at the root so the page stays locked while inner areas scroll correctly.

- **Bug Fixes**
  - Removed overflow-hidden from ChatPanelV2 root, main content, chat wrapper, right panel, and mobile layout.
  - Dropped min-h-0 from message rows to prevent hidden scroll children.
  - Inner scroll now works via overflow-y-auto; root h-screen still prevents page-level scrolling.

<sup>Written for commit 2375fb245ab6cc0c55ba543f473b51751c0953ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

