### PR TITLE
fix: contain chat panel message overflow to prevent page horizontal s…

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -316,7 +316,7 @@ const ExpandableUserMessage = ({
     <>
     <div className="relative w-full">
       <div className="bg-card text-card-foreground border rounded-xl overflow-hidden relative shadow-sm w-full flex flex-col">
-        <div className="p-4 break-words overflow-wrap-anywhere">
+        <div className="p-4 break-words overflow-hidden" style={{ overflowWrap: 'anywhere' }}>
           {/* Image previews */}
           {images && images.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-3">
@@ -344,7 +344,7 @@ const ExpandableUserMessage = ({
             /* Show full content when expanded with scrollable area */
             <div
               ref={contentRef}
-              className="max-h-[300px] overflow-y-auto"
+              className="max-h-[300px] overflow-y-auto overflow-x-hidden"
               style={{
                 scrollBehavior: 'smooth',
                 WebkitOverflowScrolling: 'touch'
@@ -5163,12 +5163,12 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
           <div
             key={message.id}
             className={cn(
-              'flex',
+              'flex min-w-0',
               message.role === 'user' ? 'justify-end' : 'justify-start'
             )}
           >
             {message.role === 'user' ? (
-              <div className="w-full">
+              <div className="w-full min-w-0">
                 <ExpandableUserMessage
                   content={message.content}
                   messageId={message.id}


### PR DESCRIPTION
…croll

- Fix remaining invalid overflow-wrap-anywhere class on truncated user message
- Add overflow-x-hidden to expanded message scroll area
- Add min-w-0 to message row flex wrapper to prevent flex children overflow
- Add min-w-0 to user message wrapper for proper width constraint

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain chat panel message overflow to stop horizontal page scroll. Tighten width constraints and fix overflow wrapping.

- **Bug Fixes**
  - Replace invalid overflow-wrap-anywhere with inline overflowWrap: 'anywhere'.
  - Add overflow-x-hidden to expanded message content area.
  - Add min-w-0 to message row flex container and user message wrapper to prevent flex child overflow.

<sup>Written for commit b7af76e47d70ef879ccf877969a7e1ac6b42be76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

