### PR TITLE
Revert "fix: guard message area overflow from leaking to workspace page"

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5390,7 +5390,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
       </div>
 
       {/* Input Area - Fixed at bottom */}
-      <div className={`border-t bg-background flex-shrink-0 ${isMobile
+      <div className={`border-t bg-background p-4 ${isMobile
         ? 'fixed bottom-12 left-0 right-0 p-4 z-[60] border-b'
         : 'p-4'
         }`}>

--- a/components/workspace/message-with-tools.tsx
+++ b/components/workspace/message-with-tools.tsx
@@ -515,7 +515,7 @@ export function MessageWithTools({ message, projectId, isStreaming = false, onCo
   
 
   return (
-    <div className="space-y-3 overflow-hidden min-w-0">
+    <div className="space-y-3">
       {/* OLD PILL SYSTEM - DISABLED IN FAVOR OF NEW INLINE PILL SYSTEM IN CHAT-PANEL-V2 */}
       {/* {hasTools && (
         <div className="space-y-2">

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -910,7 +910,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
   }
 
   return (
-    <div className="h-screen max-h-screen flex bg-background relative overflow-hidden">
+    <div className="h-screen flex bg-background relative">
       {/* Desktop Layout */}
       {!isMobile && (
         <>
@@ -1025,7 +1025,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
             {!isLoadingProjects && clientProjects.length > 0 && selectedProject && (
               <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
                 {/* Left Panel - Chat (Resizable) */}
-                <ResizablePanel defaultSize={40} minSize={20} maxSize={40} className="overflow-hidden">
+                <ResizablePanel defaultSize={40} minSize={20} maxSize={40}>
                   <div className="h-full flex flex-col overflow-hidden border-r border-border">
                     <ChatPanelV2
                       key={`chat-${selectedProject.id}-${chatSessionKey}`}


### PR DESCRIPTION
This reverts commit 2c5631499ca8480ca5aeef39936a9c6e8a2c2444.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the overflow guard in the workspace that clipped chat content and broke scrolling. Restores the previous layout and consistent chat input padding.

- **Bug Fixes**
  - Removed overflow-hidden/max-h-screen on workspace root and left panel to restore normal scrolling.
  - Dropped overflow-hidden/min-w-0 on message container so tools and content render fully.
  - Moved p-4 to the chat input base class to keep padding across breakpoints while keeping mobile fixed positioning.

<sup>Written for commit aebc331ff1197b749fd369d65566927918198067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

