### PR TITLE
debug: add MCP header logging to diagnose Supabase 401

### DIFF
--- a/app/api/chat-v2/route.ts
+++ b/app/api/chat-v2/route.ts
@@ -2242,6 +2242,9 @@ export async function POST(req: Request) {
       supabaseUserId = metadata.supabaseUserId || supabaseUserId
       stripeApiKey = metadata.stripeApiKey || stripeApiKey
       mcpServers = metadata.mcpServers || mcpServers
+      if (mcpServers && mcpServers.length > 0) {
+        console.log(`[Chat-V2] 🔍 MCP servers from metadata:`, JSON.stringify(mcpServers.map((s: any) => ({ name: s.name, url: s.url?.slice(0, 40), hasHeaders: !!s.headers, headerKeys: Object.keys(s.headers || {}) }))))
+      }
     }
 
     // Use fileTree from binary metadata if available, otherwise from JSON
@@ -10370,6 +10373,7 @@ ${fileAnalysis.filter(file => file.score < 70).map(file => `- **${file.name}**: 
         try {
           if (!server.url) continue
           const headers: Record<string, string> = { ...(server.headers || {}) }
+          console.log(`[Chat-V2] 🔌 Server "${server.name}" headers keys: [${Object.keys(headers).join(', ')}], has auth: ${!!headers['Authorization']}`)
           const transportType = server.transport === 'sse' ? 'sse' : 'http'
           const client = await createMCPClient({
             transport: {


### PR DESCRIPTION
Adds logging to show what headers are being received from the client metadata and what's being passed to createMCPClient, to diagnose why the Authorization header may not be reaching the Supabase MCP.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add debug logging to chat-v2 POST to show MCP servers from request metadata and the header keys forwarded to createMCPClient, including whether Authorization is present. This helps diagnose Supabase MCP 401s by verifying headers are received and passed through.

<sup>Written for commit 7cc8378161e6a719d14a9d8c668c5937baa270c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

