### PR TITLE
style: replace mic icon with waveform SVG matching Anthropic's design

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -6574,7 +6574,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                 )}
               </div>
 
-              {/* Voice Button */}
+              {/* Voice Button - Waveform icon */}
               <Button
                 type="button"
                 variant="ghost"
@@ -6583,7 +6583,25 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                 onClick={handleMicrophoneClick}
                 disabled={isTranscribing || isLoading}
               >
-                {isRecording ? <MicOff className="size-4 text-red-400" /> : <Mic className="size-4" />}
+                {isRecording ? (
+                  <svg width="16" height="16" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg" className="text-red-400 animate-pulse">
+                    <rect x="0" y="7.5" height="6" fill="currentColor" width="1" rx="0.5" ry="0.5" />
+                    <rect x="4" y="5.5" height="10" fill="currentColor" width="1" rx="0.5" ry="0.5" />
+                    <rect x="8" y="2.5" height="16" fill="currentColor" width="1" rx="0.5" ry="0.5" />
+                    <rect x="12" y="5.5" height="10" fill="currentColor" width="1" rx="0.5" ry="0.5" />
+                    <rect x="16" y="2.5" height="16" fill="currentColor" width="1" rx="0.5" ry="0.5" />
+                    <rect x="20" y="7.5" height="6" fill="currentColor" width="1" rx="0.5" ry="0.5" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <rect x="0" y="7.5" height="6" fill="currentColor" fillOpacity="0.5" width="1" rx="0.5" ry="0.5" />
+                    <rect x="4" y="5.5" height="10" fill="currentColor" fillOpacity="0.5" width="1" rx="0.5" ry="0.5" />
+                    <rect x="8" y="2.5" height="16" fill="currentColor" fillOpacity="0.5" width="1" rx="0.5" ry="0.5" />
+                    <rect x="12" y="5.5" height="10" fill="currentColor" fillOpacity="0.5" width="1" rx="0.5" ry="0.5" />
+                    <rect x="16" y="2.5" height="16" fill="currentColor" fillOpacity="0.5" width="1" rx="0.5" ry="0.5" />
+                    <rect x="20" y="7.5" height="6" fill="currentColor" fillOpacity="0.5" width="1" rx="0.5" ry="0.5" />
+                  </svg>
+                )}
               </Button>
             </div>
 


### PR DESCRIPTION
Use audio waveform bars instead of mic/mic-off icons. Idle state shows 50% opacity bars, recording state shows red pulsing bars.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the mic/mic-off icons in the chat panel’s voice button with a waveform SVG to match Anthropic’s design. Idle now shows 50% opacity bars, and recording shows red pulsing bars for clearer state feedback.

<sup>Written for commit 9b46811f3e48d1859fa162310f3f221fd937fdfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

