### PR TITLE
refactor: consolidate model selector into chat panel input bar

### DIFF
--- a/components/ui/model-selector.tsx
+++ b/components/ui/model-selector.tsx
@@ -118,13 +118,11 @@ export function ModelSelector({
   const truncateModelName = (text: string | undefined) => {
     if (!text) return '';
 
-    // For "auto" model, truncate to 3 chars but no ellipsis
-    if (text.toLowerCase() === 'auto') {
-      return text.length > 3 ? text.substring(0, 3) : text;
-    }
+    // Strip "PiPilot " prefix for compact display
+    const cleaned = text.replace(/^PiPilot\s+/i, '')
 
-    // For all other models, truncate to 3 characters with ellipsis
-    return text.length > 3 ? text.substring(0, 3) + '...' : text;
+    // Truncate to 10 characters with ellipsis
+    return cleaned.length > 10 ? cleaned.substring(0, 10) + '...' : cleaned;
   };
 
   if (compact) {

--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -6623,11 +6623,13 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
-                    className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs transition-colors ${isAskMode ? 'bg-blue-600/20 text-blue-400 border border-blue-600/30' : 'text-gray-400 hover:bg-gray-800'}`}
+                    className={`relative px-3 py-1 rounded-full text-xs font-medium transition-all duration-200 ${isAskMode
+                      ? 'bg-blue-500 text-white shadow-sm shadow-blue-500/25'
+                      : 'bg-gray-800 text-gray-400 hover:text-gray-300 hover:bg-gray-700'
+                    }`}
                     onClick={() => setIsAskMode(!isAskMode)}
                   >
-                    <Eye className="size-3.5" />
-                    <span>Plan</span>
+                    Plan
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>

--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -58,7 +58,6 @@ import {
   VisualEditorWrapper,
   VisualEditorToggle,
 } from "./visual-editor-wrapper";
-import { ModelSelector } from "@/components/ui/model-selector";
 import { ChatSessionSelector } from "@/components/ui/chat-session-selector";
 import type { StyleChange, Theme } from "@/lib/visual-editor";
 import dynamic from "next/dynamic";
@@ -2929,26 +2928,17 @@ export default function TodoApp() {
             }}
           >
             <WebPreviewNavigation className="fixed top-0 left-0 right-0 z-50 bg-card border-b border-border">
-              {/* Model Selector and Chat Session Selector */}
-              {project && selectedModel && onModelChange && (
+              {/* Chat Session Selector */}
+              {project && userId && onSessionChange && (
                 <div className="flex items-center gap-1 ml-2">
-                  <ModelSelector
-                    selectedModel={selectedModel}
-                    onModelChange={onModelChange}
-                    userPlan={userPlan}
-                    subscriptionStatus={subscriptionStatus}
+                  <ChatSessionSelector
+                    workspaceId={project.id}
+                    userId={userId}
+                    currentSessionId={currentSessionId || null}
+                    onSessionChange={onSessionChange}
+                    onNewSession={onNewSession}
                     compact={true}
                   />
-                  {userId && onSessionChange && (
-                    <ChatSessionSelector
-                      workspaceId={project.id}
-                      userId={userId}
-                      currentSessionId={currentSessionId || null}
-                      onSessionChange={onSessionChange}
-                      onNewSession={onNewSession}
-                      compact={true}
-                    />
-                  )}
                 </div>
               )}
 

--- a/components/workspace/project-header.tsx
+++ b/components/workspace/project-header.tsx
@@ -7,7 +7,6 @@ import { Logo } from "@/components/ui/logo"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import React, { useState, useEffect } from 'react'
 import type { Workspace as Project } from "@/lib/storage-manager"
-import { ModelSelector } from "@/components/ui/model-selector"
 import { ChatSessionSelector } from "@/components/ui/chat-session-selector"
 import { useGitHubPush } from "@/hooks/use-github-push"
 import {
@@ -258,13 +257,6 @@ export function ProjectHeader({
           </div>
         </div>
         <div className="flex items-center space-x-2">
-          {/* Model selector only when project is selected */}
-          {project && selectedModel && onModelChange && (
-            <ModelSelector
-              selectedModel={selectedModel}
-              onModelChange={onModelChange}
-            />
-          )}
           {/* Create project button */}
           <Dialog open={isCreateDialogOpen} onOpenChange={(open) => {
             setIsCreateDialogOpen(open)
@@ -356,20 +348,6 @@ export function ProjectHeader({
           )}
         </div>
        
-        {/* Model label and selector */}
-        {selectedModel && onModelChange && (
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-medium text-muted-foreground">Model:</span>
-            <ModelSelector
-              selectedModel={selectedModel}
-              onModelChange={onModelChange}
-              userPlan={userPlan}
-              subscriptionStatus={subscriptionStatus}
-              compact={true}
-            />
-          </div>
-        )}
-
         {/* Chat Session Selector */}
         {project && user && (
           <ChatSessionSelector

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -34,7 +34,6 @@ import { useAutoCloudBackup } from '@/hooks/use-auto-cloud-backup'
 import { useSubscriptionCache } from '@/hooks/use-subscription-cache'
 import { restoreBackupFromCloud, isCloudSyncEnabled } from '@/lib/cloud-sync'
 import { generateFileUpdate, type StyleChange } from '@/lib/visual-editor'
-import { ModelSelector } from "@/components/ui/model-selector"
 import { ChatSessionSelector } from "@/components/ui/chat-session-selector"
 import { AiModeSelector, type AIMode } from "@/components/ui/ai-mode-selector"
 import { DEFAULT_CHAT_MODEL } from "@/lib/ai-models"
@@ -1448,17 +1447,9 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
               </div>
             </div>
             
-            {/* Model Selector and Chat Session Selector for mobile */}
+            {/* Chat Session Selector for mobile */}
             {selectedProject && (
               <div className="flex-1 max-w-56 mx-2 flex items-center gap-1">
-                <ModelSelector
-                  selectedModel={selectedModel}
-                  onModelChange={setSelectedModel}
-                  userPlan={userPlan}
-                  subscriptionStatus={subscriptionStatus}
-                  compact={true}
-                  className="flex-1"
-                />
                 <ChatSessionSelector
                   workspaceId={selectedProject.id}
                   userId={user.id}


### PR DESCRIPTION
- Remove ModelSelector from ProjectHeader (desktop)
- Remove ModelSelector from mobile header bar
- Remove ModelSelector from CodePreviewPanel preview header
- Clean up unused ModelSelector imports from all three files
- Truncate model names at 10 chars (was 3) with "PiPilot " prefix stripped
- Redesign Plan toggle: rounded pill, solid blue bg when active, no icon

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the ModelSelector into the chat input bar and removed duplicate selectors from headers to simplify the UI. Also improved label truncation and refreshed the Plan toggle styling.

- **Refactors**
  - Removed ModelSelector from ProjectHeader (desktop), mobile header, and CodePreviewPanel header.
  - Cleaned up related imports.

- **UI Improvements**
  - Truncate model names to 10 chars and strip the "PiPilot " prefix.
  - Plan toggle: rounded pill, solid blue when active, no icon.

<sup>Written for commit 44b53b475ce5af5d3b1962545ec557a35a61538a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

