### PR TITLE
fix: remove overflow-hidden from input card to prevent popover clipping

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5686,7 +5686,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
         )}
 
         {/* Main Input Container - Claude-style rounded card */}
-        <div className="relative rounded-2xl border border-gray-700/60 bg-gray-900/80 focus-within:border-gray-600 transition-colors overflow-hidden">
+        <div className="relative rounded-2xl border border-gray-700/60 bg-gray-900/80 focus-within:border-gray-600 transition-colors">
 
           {/* Tagged Component Context */}
           {taggedComponent && (


### PR DESCRIPTION
The model selector dropdown and command menu were being cut off by overflow-hidden on the card container.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed overflow-hidden from the chat input card container to prevent popover clipping. The model selector dropdown and command menu now display fully.

<sup>Written for commit 8fcfa805467204f4335f0b004116a1558b7e56c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

