### PR TITLE
feat: unified dark theme across all workspace components

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -269,7 +269,7 @@ const ExpandableUserMessage = ({
               </p>
             </div>
           </div>
-          <div className="flex items-center justify-end gap-0.5 mt-1 opacity-0 hover:opacity-100 transition-opacity">
+          <div className="flex items-center justify-end gap-0.5 mt-1 sm:opacity-0 sm:hover:opacity-100 transition-opacity">
             <Action tooltip="Retry message" onClick={handleIconClick}>
               <ArrowUp className="w-3.5 h-3.5 text-gray-500 hover:text-gray-300" />
             </Action>

--- a/components/workspace/code-editor.tsx
+++ b/components/workspace/code-editor.tsx
@@ -977,11 +977,11 @@ export function CodeEditor({ file, onSave, projectFiles = [] }: CodeEditorProps)
 
   if (!file) {
     return (
-      <div className="h-full flex items-center justify-center bg-muted/20">
+      <div className="h-full flex items-center justify-center bg-gray-950">
         <div className="text-center">
-          <FileText className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <h3 className="text-lg font-semibold mb-2">No File Selected</h3>
-          <p className="text-muted-foreground">Select a file from the explorer to start editing</p>
+          <FileText className="h-12 w-12 text-gray-600 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-gray-300 mb-2">No File Selected</h3>
+          <p className="text-gray-500">Select a file from the explorer to start editing</p>
         </div>
       </div>
     )
@@ -1054,11 +1054,11 @@ export function CodeEditor({ file, onSave, projectFiles = [] }: CodeEditorProps)
         `
       }} />
       {/* Editor Header */}
-      <div className="flex items-center justify-between p-3 border-b border-border bg-card flex-shrink-0">
+      <div className="flex items-center justify-between p-3 border-b border-gray-800/60 bg-gray-900/80 flex-shrink-0">
         <div className="flex items-center space-x-2">
-          <FileText className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium">{file.name}</span>
-          {hasChanges && <div className="w-2 h-2 bg-accent rounded-full" />}
+          <FileText className="h-4 w-4 text-gray-500" />
+          <span className="text-sm font-medium text-gray-200">{file.name}</span>
+          {hasChanges && <div className="w-2 h-2 bg-blue-500 rounded-full" />}
         </div>
         <div className="flex items-center space-x-2">
           <Button 

--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -2869,11 +2869,11 @@ export default function TodoApp() {
 
   if (!project) {
     return (
-      <div className="flex-1 flex items-center justify-center bg-muted/20">
+      <div className="flex-1 flex items-center justify-center bg-gray-950">
         <div className="text-center">
-          <FileText className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <h3 className="text-lg font-semibold mb-2">No Project Selected</h3>
-          <p className="text-muted-foreground">Select a project from the sidebar to start building</p>
+          <FileText className="h-12 w-12 text-gray-600 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-gray-300 mb-2">No Project Selected</h3>
+          <p className="text-gray-500">Select a project from the sidebar to start building</p>
         </div>
       </div>
     )
@@ -2883,7 +2883,7 @@ export default function TodoApp() {
     <div className="flex flex-col h-full">
       {/* Tabs - Hidden on mobile and when in preview tab on desktop */}
       {!isMobile && activeTab !== "preview" && (
-        <div className="border-b border-border bg-card">
+        <div className="border-b border-gray-800/60 bg-gray-900/80">
           <div className="flex items-center justify-between px-4 py-2">
             <div className="flex space-x-1">
               {/* Desktop tabs would go here if needed */}
@@ -2927,7 +2927,7 @@ export default function TodoApp() {
               setPreview(prev => ({ ...prev, url }))
             }}
           >
-            <WebPreviewNavigation className="fixed top-0 left-0 right-0 z-50 bg-card border-b border-border">
+            <WebPreviewNavigation className="fixed top-0 left-0 right-0 z-50 bg-gray-900/95 backdrop-blur-sm border-b border-gray-800/60">
               {/* Chat Session Selector */}
               {project && userId && onSessionChange && (
                 <div className="flex items-center gap-1 ml-2">

--- a/components/workspace/file-explorer.tsx
+++ b/components/workspace/file-explorer.tsx
@@ -1556,9 +1556,9 @@ enabled = false`
         <ContextMenu>
             <ContextMenuTrigger>
             <div
-              className={`flex items-center space-x-2 px-2 py-1.5 hover:bg-accent/50 rounded cursor-pointer transition-colors ${
-                isSelected ? "bg-accent text-accent-foreground" : ""
-              } ${isSearchMatch ? "bg-yellow-100 dark:bg-yellow-900/20" : ""} ${node.type === 'folder' && node.path === dragOverFolder ? 'bg-sky-100 dark:bg-sky-900/20 ring-1 ring-sky-300' : ''}`}
+              className={`flex items-center space-x-2 px-2 py-1.5 hover:bg-gray-800/60 rounded cursor-pointer transition-colors ${
+                isSelected ? "bg-gray-800 text-gray-100" : "text-gray-400"
+              } ${isSearchMatch ? "bg-yellow-900/20" : ""} ${node.type === 'folder' && node.path === dragOverFolder ? 'bg-sky-900/20 ring-1 ring-sky-600' : ''}`}
               style={{ paddingLeft: `${depth * 16 + 8}px` }}
               onClick={() => {
                 if (node.type === "folder") {
@@ -1571,9 +1571,9 @@ enabled = false`
               {node.type === "folder" ? (
                 <>
                   {node.expanded ? (
-                    <ChevronDown className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                    <ChevronDown className="h-3 w-3 text-gray-500 flex-shrink-0" />
                   ) : (
-                    <ChevronRight className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+                    <ChevronRight className="h-3 w-3 text-gray-500 flex-shrink-0" />
                   )}
                   {node.expanded ? (
                     <FolderOpen className="h-4 w-4 text-blue-500 flex-shrink-0" />
@@ -1702,7 +1702,7 @@ enabled = false`
 
   if (!project) {
     return (
-      <div className="p-4 text-center text-muted-foreground">
+      <div className="p-4 text-center text-gray-500">
         <FileText className="h-8 w-8 mx-auto mb-2 opacity-50" />
         <p className="text-sm">Select a project to view files</p>
       </div>
@@ -1710,9 +1710,9 @@ enabled = false`
   }
 
   return (
-    <div className="flex flex-col h-full border-r border-border">
+    <div className="flex flex-col h-full border-r border-gray-800/60 bg-gray-950">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b border-border bg-card">
+      <div className="flex items-center justify-between p-4 border-b border-gray-800/60 bg-gray-900/80">
         <h3 className="text-sm font-semibold flex items-center">
           <Folder className="w-4 h-4 mr-2" />
           Files
@@ -1774,7 +1774,7 @@ enabled = false`
           onDrop={(e) => handleDropUpload(e, null)}
         >
           {files.length === 0 ? (
-            <div className="p-4 text-center text-muted-foreground">
+            <div className="p-4 text-center text-gray-500">
               <Folder className="h-8 w-8 mx-auto mb-2 opacity-50" />
               <p className="text-sm">No files yet</p>
               <p className="text-xs">Create your first file or drag & drop files to get started</p>
@@ -1789,21 +1789,21 @@ enabled = false`
 
       {/* Upload Progress Indicator */}
       {isUploading && (
-        <div className="border-t border-border p-2">
+        <div className="border-t border-gray-800/60 p-2">
           <div className="flex items-center space-x-2">
-            <Upload className="h-4 w-4 text-muted-foreground" />
+            <Upload className="h-4 w-4 text-gray-500" />
             <div className="flex-1">
-              <div className="text-xs text-muted-foreground mb-1">
+              <div className="text-xs text-gray-500 mb-1">
                 Uploading files{uploadInFolder ? ` to ${uploadInFolder}` : ''}...
               </div>
-              <div className="w-full bg-secondary rounded-full h-1.5">
-                <div 
-                  className="bg-primary h-1.5 rounded-full transition-all duration-300"
+              <div className="w-full bg-gray-800 rounded-full h-1.5">
+                <div
+                  className="bg-blue-500 h-1.5 rounded-full transition-all duration-300"
                   style={{ width: `${uploadProgress}%` }}
                 />
               </div>
             </div>
-            <div className="text-xs text-muted-foreground">
+            <div className="text-xs text-gray-500">
               {Math.round(uploadProgress)}%
             </div>
           </div>

--- a/components/workspace/modern-sidebar.tsx
+++ b/components/workspace/modern-sidebar.tsx
@@ -156,7 +156,7 @@ export function ModernSidebar({
     <>
       <div className="flex flex-col flex-1 w-full">
         {/* Header with Logo and Close Button */}
-        <div className={`flex items-center w-full h-14 px-3 border-b border-gray-800 ${shouldExpand ? 'justify-between' : 'justify-center'}`}>
+        <div className={`flex items-center w-full h-14 px-3 border-b border-gray-800/60 ${shouldExpand ? 'justify-between' : 'justify-center'}`}>
           <div className="flex items-center cursor-pointer" onClick={() => window.location.href = '/'}>
             <div className="w-10 h-10 bg-gradient-to-br rounded-lg flex-shrink-0 flex items-center justify-center">
               <img src="https://pipilot.dev/logo.png" alt="Logo" className="w-8 h-8 object-contain" />
@@ -349,7 +349,7 @@ export function ModernSidebar({
       </div>
 
       {/* Bottom Navigation */}
-      <div className="flex flex-col space-y-1 px-2 pb-3 border-t border-gray-800 pt-3">
+      <div className="flex flex-col space-y-1 px-2 pb-3 border-t border-gray-800/60 pt-3">
         {/* Database */}
         <button
           onClick={() => handleNavigation('/database')}
@@ -437,7 +437,7 @@ export function ModernSidebar({
         {/* Mobile Sidebar - only renders when open */}
         {isMobileOpen && (
           <aside
-            className="lg:hidden fixed inset-y-0 left-0 z-[70] w-64 bg-black flex flex-col border-r border-gray-800"
+            className="lg:hidden fixed inset-y-0 left-0 z-[70] w-64 bg-gray-950 flex flex-col border-r border-gray-800/60"
             role="dialog"
             aria-modal="true"
           >
@@ -526,7 +526,7 @@ export function ModernSidebar({
   return (
     <>
       <aside
-        className={`hidden lg:flex bg-black flex-col border-r border-gray-800 transition-all duration-300 relative ${
+        className={`hidden lg:flex bg-gray-950 flex-col border-r border-gray-800/60 transition-all duration-300 relative ${
           shouldExpand ? 'w-64' : 'w-14'
         }`}
         onMouseEnter={() => setIsHovered(true)}

--- a/components/workspace/project-header.tsx
+++ b/components/workspace/project-header.tsx
@@ -248,7 +248,7 @@ export function ProjectHeader({
   }
   if (!project) {
     return (
-      <div className="h-16 border-b border-border bg-card px-6 flex items-center justify-between">
+      <div className="h-16 border-b border-gray-800/60 bg-gray-900/80 px-6 flex items-center justify-between">
         <div className="flex items-center space-x-4">
           <Logo variant="icon" size="sm" />
           <div>
@@ -327,7 +327,7 @@ export function ProjectHeader({
           {editing ? (
             <input
               type="text"
-              className="text-lg font-semibold text-card-foreground bg-background border border-border rounded px-2 py-1 w-40 focus:outline-none focus:ring-2 focus:ring-primary"
+              className="text-lg font-semibold text-gray-100 bg-gray-800 border border-gray-700 rounded px-2 py-1 w-40 focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={nameInput}
               autoFocus
               onChange={e => setNameInput(e.target.value)}

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -909,7 +909,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
   }
 
   return (
-    <div className="h-screen flex bg-background relative">
+    <div className="h-screen flex bg-gray-950 relative">
       {/* Desktop Layout */}
       {!isMobile && (
         <>
@@ -1025,7 +1025,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
               <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
                 {/* Left Panel - Chat (Resizable) */}
                 <ResizablePanel defaultSize={40} minSize={20} maxSize={40}>
-                  <div className="h-full flex flex-col overflow-hidden border-r border-border">
+                  <div className="h-full flex flex-col overflow-hidden border-r border-gray-800/60">
                     <ChatPanelV2
                       key={`chat-${selectedProject.id}-${chatSessionKey}`}
                       project={selectedProject}
@@ -1048,7 +1048,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                   <div className="h-full flex flex-col overflow-hidden">
                     {/* Tab Switcher with Preview Controls - Hidden when in preview mode */}
                     {activeTab !== "preview" && (
-                      <div className="border-b border-border bg-card p-2 flex-shrink-0">
+                      <div className="border-b border-gray-800/60 bg-gray-900/80 p-2 flex-shrink-0">
                         <div className="flex items-center justify-between">
                           <div className="flex space-x-1">
                             <Button
@@ -1096,7 +1096,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                       <ResizablePanelGroup direction="horizontal" className="flex-1 min-h-0">
                         {/* File Explorer Panel */}
                         <ResizablePanel defaultSize={25} minSize={20} maxSize={35}>
-                          <div className="h-full flex flex-col border-r border-border">
+                          <div className="h-full flex flex-col border-r border-gray-800/60">
                             <FileExplorer
                               key={fileExplorerKey}
                               project={selectedProject}
@@ -1239,7 +1239,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
             {/* Status Bar */}
             {selectedProject && (
-              <div className="h-8 flex-shrink-0 border-t border-border bg-muted/50 flex items-center justify-between px-4 text-xs">
+              <div className="h-8 flex-shrink-0 border-t border-gray-800/60 bg-gray-900/60 flex items-center justify-between px-4 text-xs text-gray-400">
                 <div className="flex items-center space-x-4">
                   {/* GitHub Status */}
                   <div className="flex items-center space-x-1">
@@ -1252,7 +1252,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                         if (gitHubConnected) {
                           return <span className="text-blue-600 dark:text-blue-400">Account Connected</span>
                         }
-                        return <span className="text-muted-foreground">Not Connected</span>
+                        return <span className="text-gray-500">Not Connected</span>
                       })()}
                     </span>
                   </div>
@@ -1264,13 +1264,13 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                       Deployment: {(() => {
                         switch (selectedProject?.deploymentStatus) {
                           case 'deployed':
-                            return <span className="text-green-600 dark:text-green-400">Live</span>
+                            return <span className="text-green-400">Live</span>
                           case 'in_progress':
-                            return <span className="text-yellow-600 dark:text-yellow-400">In Progress</span>
+                            return <span className="text-yellow-400">In Progress</span>
                           case 'failed':
-                            return <span className="text-red-600 dark:text-red-400">Failed</span>
+                            return <span className="text-red-400">Failed</span>
                           default:
-                            return <span className="text-muted-foreground">Not Deployed</span>
+                            return <span className="text-gray-500">Not Deployed</span>
                         }
                       })()}
                     </span>
@@ -1330,7 +1330,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
           />
 
           {/* Fixed Mobile Header */}
-          <div className="fixed top-0 left-0 right-0 h-14 border-b border-border bg-card flex items-center justify-between px-4 z-40">
+          <div className="fixed top-0 left-0 right-0 h-14 border-b border-gray-800/60 bg-gray-900/95 backdrop-blur-sm flex items-center justify-between px-4 z-40">
             <div className="flex items-center space-x-3">
               <Button 
                 variant="ghost" 
@@ -1678,52 +1678,52 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
           {/* Fixed Mobile Bottom Tab Navigation - only show when project is selected */}
           {selectedProject && (
-            <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-border z-50">
+            <div className="fixed bottom-0 left-0 right-0 bg-gray-900/95 backdrop-blur-sm border-t border-gray-800/60 z-50">
               <div className="grid grid-cols-5 h-12">
                 <button
                   onClick={() => setMobileTab("chat")}
                   className={`flex flex-col items-center justify-center space-y-1 transition-colors ${
-                    mobileTab === "chat" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground"
+                    mobileTab === "chat" ? "bg-gray-800 text-white" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <MessageSquare className="h-4 w-4" />
-                  <span className="text-xs">Chat</span>
+                  <span className="text-[10px]">Chat</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("files")}
                   className={`flex flex-col items-center justify-center space-y-1 transition-colors ${
-                    mobileTab === "files" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground"
+                    mobileTab === "files" ? "bg-gray-800 text-white" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <FileText className="h-4 w-4" />
-                  <span className="text-xs">Files</span>
+                  <span className="text-[10px]">Files</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("editor")}
                   className={`flex flex-col items-center justify-center space-y-1 transition-colors ${
-                    mobileTab === "editor" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground"
+                    mobileTab === "editor" ? "bg-gray-800 text-white" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <Code className="h-4 w-4" />
-                  <span className="text-xs">Editor</span>
+                  <span className="text-[10px]">Editor</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("preview")}
                   className={`flex flex-col items-center justify-center space-y-1 transition-colors ${
-                    mobileTab === "preview" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground"
+                    mobileTab === "preview" ? "bg-gray-800 text-white" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <Eye className="h-4 w-4" />
-                  <span className="text-xs">Preview</span>
+                  <span className="text-[10px]">Preview</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("audit")}
                   className={`flex flex-col items-center justify-center space-y-1 transition-colors ${
-                    mobileTab === "audit" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground"
+                    mobileTab === "audit" ? "bg-gray-800 text-white" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <Shield className="h-4 w-4" />
-                  <span className="text-xs">Audit</span>
+                  <span className="text-[10px]">Audit</span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
- Fix mobile user message action buttons: always visible on mobile (sm:opacity-0 sm:hover:opacity-100 instead of opacity-0 hover:opacity-100)
- Workspace layout: bg-gray-950 root, consistent border-gray-800/60 borders
- Sidebar: bg-gray-950, softer border-gray-800/60 dividers
- Mobile header: bg-gray-900/95 with backdrop-blur-sm
- Mobile bottom tabs: bg-gray-900/95, active state bg-gray-800 text-white, inactive text-gray-500
- PC tab switcher: bg-gray-900/80 with border-gray-800/60
- Status bar: bg-gray-900/60, text-gray-400, explicit color status labels
- File explorer: bg-gray-950, header bg-gray-900/80, selected item bg-gray-800
- Code editor: header bg-gray-900/80, empty state bg-gray-950
- Code preview panel: navigation bg-gray-900/95 with backdrop-blur
- Project header: bg-gray-900/80, dark input styling for rename

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the dark theme across the workspace for consistent colors and contrast on desktop and mobile. Also makes mobile user message actions always visible.

- **New Features**
  - Workspace root now uses bg-gray-950 with consistent border-gray-800/60 dividers.
  - Navigation and tabs (sidebar, headers, desktop switcher, mobile header/bottom tabs, preview nav) updated to bg-gray-900/80–95 with improved contrast and backdrop-blur where appropriate.
  - Editor and File Explorer use dark backgrounds, gray text, selected row bg-gray-800, and blue accents for change indicators and upload progress.
  - Status bar now bg-gray-900/60 with text-gray-400 and explicit status colors; project rename input has dark styling with a blue focus ring.

- **Bug Fixes**
  - Mobile: user message action buttons are visible by default (hover-only on ≥sm).

<sup>Written for commit adb295e61afefbfff75f7b8b505cc22e7d28e276. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

