### PR TITLE
style: apply orange accent color across all workspace components

### DIFF
--- a/components/project-grid.tsx
+++ b/components/project-grid.tsx
@@ -623,7 +623,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
           </p>
           <Link
             href="/auth/login"
-            className="inline-flex items-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors duration-200"
+            className="inline-flex items-center px-6 py-3 bg-orange-600 hover:bg-orange-500 text-white font-semibold rounded-lg transition-colors duration-200"
           >
             Sign In to Continue
           </Link>
@@ -644,7 +644,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
           </p>
           <Link
             href="/pc-workspace"
-            className="inline-flex items-center px-6 py-3 mt-4 bg-green-600 hover:bg-green-700 text-white font-semibold rounded-lg transition-colors duration-200"
+            className="inline-flex items-center px-6 py-3 mt-4 bg-orange-600 hover:bg-orange-500 text-white font-semibold rounded-lg transition-colors duration-200"
           >
             Create Your First Project
           </Link>
@@ -673,7 +673,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
           <div key={project.id} className="relative group">
             <Link href={`/workspace?projectId=${project.id}`} className="group">
               <Card className="bg-white/5 border-white/10 hover:bg-white/10 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl cursor-pointer overflow-hidden">
-                <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-blue-900/50 via-purple-900/50 to-pink-900/50">
+                <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-orange-950/30 via-gray-900/50 to-gray-950/50">
                   <Image
                     src={project.thumbnail}
                     alt={project.name}
@@ -687,13 +687,13 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
                     </Badge>
                   </div>
                   <div className="absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-2 group-hover:translate-y-0">
-                    <div className="p-2 bg-blue-500 rounded-full shadow-lg">
+                    <div className="p-2 bg-orange-600 rounded-full shadow-lg">
                       <ExternalLink className="w-4 h-4 text-white" />
                     </div>
                   </div>
                 </div>
                 <CardContent className="p-5 bg-gradient-to-b from-white/5 to-transparent">
-                  <h3 className="text-white font-bold text-lg mb-2 group-hover:text-blue-400 transition-colors line-clamp-1">
+                  <h3 className="text-white font-bold text-lg mb-2 group-hover:text-orange-400 transition-colors line-clamp-1">
                     {project.name}
                   </h3>
                   <p className="text-white/60 text-sm line-clamp-2 mb-3">
@@ -707,7 +707,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
                       {timeAgo(project.createdAt)}
                     </div>
                     <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <span className="text-xs text-blue-400 font-medium">Open →</span>
+                      <span className="text-xs text-orange-400 font-medium">Open →</span>
                     </div>
                   </div>
                 </CardContent>
@@ -722,7 +722,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
             </button>
             <button
               onClick={(e) => handleCloneProject(project.id, e)}
-              className="absolute top-3 left-16 p-2 bg-blue-500/90 hover:bg-blue-600 backdrop-blur-sm text-white rounded-full opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-all duration-200 z-10 shadow-lg hover:scale-110"
+              className="absolute top-3 left-16 p-2 bg-orange-500/90 hover:bg-orange-600 backdrop-blur-sm text-white rounded-full opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-all duration-200 z-10 shadow-lg hover:scale-110"
               title="Clone project"
             >
               <Copy className="w-4 h-4" />
@@ -810,7 +810,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
       }}>
         <DialogContent className="bg-gray-900 border-gray-800 text-white">
           <DialogHeader>
-            <DialogTitle className="text-blue-400">Clone Project</DialogTitle>
+            <DialogTitle className="text-orange-400">Clone Project</DialogTitle>
             <DialogDescription className="text-gray-300">
               Create a copy of <span className="font-semibold text-white">"{cloneProject?.name}"</span> with all its files.
             </DialogDescription>
@@ -841,7 +841,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
             <Button
               onClick={confirmCloneProject}
               disabled={!cloneName.trim()}
-              className="bg-blue-600 hover:bg-blue-700"
+              className="bg-orange-600 hover:bg-orange-500"
             >
               Clone Project
             </Button>

--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5659,7 +5659,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
         {showScrollButton && (
           <button
             onClick={scrollToBottom}
-            className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 h-8 w-8 rounded-full bg-gray-700/90 border border-gray-600/50 text-gray-300 hover:bg-gray-600/90 hover:text-white flex items-center justify-center shadow-lg backdrop-blur-sm transition-all"
+            className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 h-8 w-8 rounded-full bg-orange-600 text-white hover:bg-orange-500 flex items-center justify-center shadow-lg transition-all"
             aria-label="Scroll to bottom"
           >
             <ArrowDown className="size-4" />

--- a/components/workspace/empty-workspace-view.tsx
+++ b/components/workspace/empty-workspace-view.tsx
@@ -137,7 +137,7 @@ export function EmptyWorkspaceView({
     <div className="h-full overflow-y-auto">
       {/* Hero Section with Gradient */}
       <div
-        className={`relative bg-gradient-to-br from-blue-900 via-purple-900 to-pink-900 pt-8 lg:pt-0 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 pb-4 sm:pb-6 transition-all duration-1000 ${
+        className={`relative bg-gradient-to-br from-orange-950 via-gray-950 to-gray-900 pt-8 lg:pt-0 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 pb-4 sm:pb-6 transition-all duration-1000 ${
           isLoaded ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
         }`}
       >
@@ -148,7 +148,7 @@ export function EmptyWorkspaceView({
           {/* Title */}
             <h1 className="text-2xl sm:text-3xl font-bold text-white text-center mt-6 mb-4 sm:mb-5 tracking-tight leading-tight px-2 sm:px-4">
               Ready to build something amazing?
-              <span className="block text-xs sm:text-sm text-pink-300 mt-2 font-normal">Let PiPilot create your next web app in seconds.</span>
+              <span className="block text-xs sm:text-sm text-orange-300 mt-2 font-normal">Let PiPilot create your next web app in seconds.</span>
             </h1>
 
           {/* Chat Input Component */}
@@ -166,14 +166,14 @@ export function EmptyWorkspaceView({
       </div>
 
       {/* Projects Section */}
-      <div className="bg-gray-900 px-4 sm:px-6 py-1 sm:py-2 flex-shrink-0">
+      <div className="bg-gray-950 px-4 sm:px-6 py-1 sm:py-2 flex-shrink-0">
         <div className="max-w-7xl mx-auto">
           <div className="flex flex-row items-center justify-between mb-2 sm:mb-3 gap-4">
             <div className="flex gap-2 w-full sm:w-auto overflow-x-auto">
               <button
                 onClick={() => setActiveTab('projects')}
                 className={`px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-medium transition-colors whitespace-nowrap ${
-                  activeTab === 'projects' ? 'bg-gray-800 text-white' : 'text-gray-400 hover:text-white'
+                  activeTab === 'projects' ? 'bg-orange-600/15 text-orange-400' : 'text-gray-400 hover:text-white'
                 }`}
               >
                 My projects
@@ -186,7 +186,7 @@ export function EmptyWorkspaceView({
                 <select
                   value={filterBy}
                   onChange={(e) => setFilterBy(e.target.value as any)}
-                  className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
                 >
                   <option value="all">All time</option>
                   <option value="recent">Last 24h</option>

--- a/components/workspace/modern-sidebar.tsx
+++ b/components/workspace/modern-sidebar.tsx
@@ -314,7 +314,7 @@ export function ModernSidebar({
                         onClick={() => handleProjectSelect(project)}
                         className={`w-full flex items-start gap-2 p-2 rounded-md transition-colors ${
                           selectedProject?.id === project.id
-                            ? 'bg-blue-600/20 text-blue-400'
+                            ? 'bg-orange-600/20 text-orange-400'
                             : 'text-gray-400 hover:text-white hover:bg-gray-800'
                         }`}
                       >
@@ -339,7 +339,7 @@ export function ModernSidebar({
             >
               <Folder size={18} />
               {projects.length > 0 && (
-                <span className="absolute -top-1 -right-1 bg-blue-600 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
+                <span className="absolute -top-1 -right-1 bg-orange-600 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
                   {projects.length > 9 ? '9+' : projects.length}
                 </span>
               )}
@@ -476,7 +476,7 @@ export function ModernSidebar({
                       onClick={() => handleProjectSelect(project)}
                       className="w-full flex items-start gap-3 p-3 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors text-left"
                     >
-                      <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-500 rounded-lg flex-shrink-0 flex items-center justify-center">
+                      <div className="w-12 h-12 bg-gradient-to-br from-orange-500 to-amber-600 rounded-lg flex-shrink-0 flex items-center justify-center">
                         <Folder className="h-6 w-6 text-white" />
                       </div>
                       <div className="flex-1 min-w-0">
@@ -566,7 +566,7 @@ export function ModernSidebar({
                     onClick={() => handleProjectSelect(project)}
                     className="w-full flex items-start gap-3 p-3 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors text-left"
                   >
-                    <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-purple-500 rounded-lg flex-shrink-0 flex items-center justify-center">
+                    <div className="w-12 h-12 bg-gradient-to-br from-orange-500 to-amber-600 rounded-lg flex-shrink-0 flex items-center justify-center">
                       <Folder className="h-6 w-6 text-white" />
                     </div>
                     <div className="flex-1 min-w-0">

--- a/components/workspace/project-header.tsx
+++ b/components/workspace/project-header.tsx
@@ -252,8 +252,8 @@ export function ProjectHeader({
         <div className="flex items-center space-x-4">
           <Logo variant="icon" size="sm" />
           <div>
-            <h1 className="text-lg font-semibold text-card-foreground">Time to Ship something new?</h1>
-            <p className="text-sm text-muted-foreground">Ask PiPilot to build your next app</p>
+            <h1 className="text-lg font-semibold text-gray-100">Time to Ship something new?</h1>
+            <p className="text-sm text-gray-500">Ask PiPilot to build your next app</p>
           </div>
         </div>
         <div className="flex items-center space-x-2">
@@ -327,7 +327,7 @@ export function ProjectHeader({
           {editing ? (
             <input
               type="text"
-              className="text-lg font-semibold text-gray-100 bg-gray-800 border border-gray-700 rounded px-2 py-1 w-40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="text-lg font-semibold text-gray-100 bg-gray-800 border border-gray-700 rounded px-2 py-1 w-40 focus:outline-none focus:ring-2 focus:ring-orange-500"
               value={nameInput}
               autoFocus
               onChange={e => setNameInput(e.target.value)}
@@ -339,7 +339,7 @@ export function ProjectHeader({
             />
           ) : (
             <h1
-              className="text-lg font-semibold text-card-foreground cursor-pointer hover:underline"
+              className="text-lg font-semibold text-gray-100 cursor-pointer hover:underline"
               title="Click to edit project name"
               onClick={() => setEditing(true)}
             >
@@ -463,10 +463,10 @@ export function ProjectHeader({
                 size="sm" 
                 onClick={handleBackupToCloud}
                 disabled={!project || isBackingUp}
-                className="h-8 w-8 p-0 sm:w-auto sm:px-3 bg-blue-600/10 border-blue-500 hover:bg-blue-600/20"
+                className="h-8 w-8 p-0 sm:w-auto sm:px-3 bg-orange-600/10 border-orange-500/50 hover:bg-orange-600/20"
               >
-                <Cloud className={`h-4 w-4 text-blue-400 ${isBackingUp ? 'animate-pulse' : ''}`} />
-                <span className="hidden sm:inline ml-2 text-blue-400">
+                <Cloud className={`h-4 w-4 text-orange-400 ${isBackingUp ? 'animate-pulse' : ''}`} />
+                <span className="hidden sm:inline ml-2 text-orange-400">
                   {isBackingUp ? "Backing up..." : "Backup"}
                 </span>
               </Button>
@@ -511,10 +511,10 @@ export function ProjectHeader({
                 size="sm" 
                 onClick={onDatabase}
                 disabled={!project}
-                className="h-8 w-8 p-0 sm:w-auto sm:px-3 bg-purple-600/10 border-purple-500 hover:bg-purple-600/20"
+                className="h-8 w-8 p-0 sm:w-auto sm:px-3 bg-orange-600/10 border-orange-500/50 hover:bg-orange-600/20"
               >
-                <Database className="h-4 w-4 text-purple-400" />
-                <span className="hidden sm:inline ml-2 text-purple-400">Database</span>
+                <Database className="h-4 w-4 text-orange-400" />
+                <span className="hidden sm:inline ml-2 text-orange-400">Database</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
@@ -527,11 +527,11 @@ export function ProjectHeader({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button 
-                size="sm" 
-                onClick={onDeploy} 
+              <Button
+                size="sm"
+                onClick={onDeploy}
                 disabled={!project}
-                className="h-8 px-3"
+                className="h-8 px-3 bg-orange-600 hover:bg-orange-500 text-white border-0"
               >
                 <Rocket className="h-4 w-4" />
                 <span className="hidden sm:inline ml-2">Deploy</span>

--- a/components/workspace/repo-agent-view.tsx
+++ b/components/workspace/repo-agent-view.tsx
@@ -1658,7 +1658,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
             {/* Hero Section */}
             <div className="text-center mb-8 max-w-3xl">
               <h1 className="text-5xl sm:text-6xl font-bold mb-3">
-                <span className="bg-gradient-to-r from-blue-400 via-purple-500 to-pink-500 bg-clip-text text-transparent">
+                <span className="bg-gradient-to-r from-orange-400 via-orange-500 to-amber-500 bg-clip-text text-transparent">
                   PiPilot SWE Agent
                 </span>
               </h1>
@@ -1781,13 +1781,13 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                         className="absolute top-full mt-2 right-0 w-72 rounded-xl overflow-hidden z-50"
                         style={{
                           background: 'rgba(17, 24, 39, 0.95)',
-                          border: '1px solid rgba(59, 130, 246, 0.2)',
+                          border: '1px solid rgba(234, 88, 12, 0.2)',
                           boxShadow: '0 8px 32px rgba(0, 0, 0, 0.6)',
                           backdropFilter: 'blur(20px)',
                           maxHeight: '300px'
                         }}
                       >
-                        <div className="p-3 border-b border-blue-500/20">
+                        <div className="p-3 border-b border-orange-500/20">
                           <p className="text-xs text-gray-400 font-medium">Conversation History</p>
                         </div>
                         <div className="overflow-y-auto max-h-64">
@@ -1810,10 +1810,10 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                                     setCurrentView('workspace')
                                     setShowHistoryDropdown(false)
                                   }}
-                                  className="w-full text-left p-3 transition-all border-none cursor-pointer hover:bg-blue-500/10"
+                                  className="w-full text-left p-3 transition-all border-none cursor-pointer hover:bg-orange-500/10"
                                   style={{
-                                    background: isCurrent ? 'rgba(59, 130, 246, 0.1)' : 'transparent',
-                                    borderBottom: '1px solid rgba(59, 130, 246, 0.1)'
+                                    background: isCurrent ? 'rgba(234, 88, 12, 0.1)' : 'transparent',
+                                    borderBottom: '1px solid rgba(234, 88, 12, 0.1)'
                                   }}
                                 >
                                   <div className="flex items-start gap-2">
@@ -1867,7 +1867,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                     <Button
                       onClick={handleLandingSubmit}
                       disabled={!landingInput.trim() || !selectedRepo || isLandingLoading || !storedTokens.github}
-                      className="h-9 px-4 rounded-lg bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium"
+                      className="h-9 px-4 rounded-lg bg-orange-600 hover:bg-orange-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium"
                     >
                       {isLandingLoading ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -1931,7 +1931,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
             <select
               value={selectedRepo}
               onChange={(e) => setSelectedRepo(e.target.value)}
-              className="selector bg-gray-800/60 border border-blue-500/30 rounded-lg px-3.5 py-2 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-blue-500"
+              className="selector bg-gray-800/60 border border-orange-500/30 rounded-lg px-3.5 py-2 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-orange-500"
               style={{
                 appearance: 'none',
                 backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239ca3af' d='M6 8.5l-4-4h8l-4 4z'/%3E%3C/svg%3E")`,
@@ -1950,7 +1950,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
             <select
               value={selectedBranch}
               onChange={(e) => setSelectedBranch(e.target.value)}
-              className="selector bg-gray-800/60 border border-blue-500/30 rounded-lg px-3.5 py-2 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-blue-500"
+              className="selector bg-gray-800/60 border border-orange-500/30 rounded-lg px-3.5 py-2 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-orange-500"
               style={{
                 appearance: 'none',
                 backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239ca3af' d='M6 8.5l-4-4h8l-4 4z'/%3E%3C/svg%3E")`,
@@ -1998,7 +1998,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                   color: 'white',
                   borderBottomRightRadius: message.isUser ? '4px' : '16px',
                   borderBottomLeftRadius: message.isUser ? '16px' : '4px',
-                  boxShadow: message.isUser ? '0 4px 20px rgba(59, 130, 246, 0.3)' : 'none',
+                  boxShadow: message.isUser ? '0 4px 20px rgba(234, 88, 12, 0.15)' : 'none',
                   animation: 'messageSlide 0.4s ease-out'
                 }}
               >
@@ -2008,7 +2008,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                     {isLongMessage && (
                       <button
                         onClick={() => toggleMessageExpansion(message.id)}
-                        className="mt-2 text-xs text-blue-200 hover:text-white flex items-center gap-1 transition-colors"
+                        className="mt-2 text-xs text-orange-200 hover:text-white flex items-center gap-1 transition-colors"
                       >
                         {isExpanded ? (
                           <>
@@ -2091,7 +2091,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
         <div className="input-area p-5 absolute bottom-0 left-0 right-0 z-10" style={{
           background: 'linear-gradient(180deg, rgba(17, 24, 39, 0.95), rgba(10, 14, 20, 0.98))',
           backdropFilter: 'blur(20px)',
-          borderTop: '1px solid rgba(59, 130, 246, 0.2)',
+          borderTop: '1px solid rgba(234, 88, 12, 0.2)',
           boxShadow: '0 -8px 32px rgba(0, 0, 0, 0.6)'
         }}>
           {/* Attachment Badges */}
@@ -2102,7 +2102,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                   key={attachment.id}
                   className="flex items-center gap-2 px-3 py-1.5 bg-gray-700/50 rounded-lg text-sm border border-gray-600/50"
                 >
-                  {attachment.type === 'file' && <FileText className="w-3.5 h-3.5 text-blue-400" />}
+                  {attachment.type === 'file' && <FileText className="w-3.5 h-3.5 text-orange-400" />}
                   {attachment.type === 'image' && <ImageIcon className="w-3.5 h-3.5 text-green-400" />}
                   {attachment.type === 'url' && <LinkIcon className="w-3.5 h-3.5 text-purple-400" />}
                   <span className="text-gray-300 truncate max-w-[150px]">
@@ -2127,7 +2127,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
           <div className="input-wrapper flex items-end gap-3 relative">
             <div className="input-container flex-1 relative overflow-hidden rounded-2xl flex flex-col min-w-0" style={{
               background: 'rgba(17, 24, 39, 0.8)',
-              border: '2px solid rgba(59, 130, 246, 0.3)',
+              border: '2px solid rgba(234, 88, 12, 0.3)',
               boxShadow: '0 4px 24px rgba(0, 0, 0, 0.4), inset 0 1px 2px rgba(255, 255, 255, 0.05)',
               transition: 'all 0.3s ease'
             }}>
@@ -2178,7 +2178,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                           }}
                           className="w-full justify-start text-sm px-2 py-2 text-gray-300 hover:bg-gray-700/50 rounded transition-colors flex items-center gap-2"
                         >
-                          <FileText className="size-4 text-blue-400" /> Upload File
+                          <FileText className="size-4 text-orange-400" /> Upload File
                         </button>
 
                         <button
@@ -2244,8 +2244,8 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                   disabled={(!currentInput.trim() && attachments.length === 0) || isLoading}
                   className="send-button w-9 h-9 flex items-center justify-center border-none rounded-full text-white cursor-pointer transition-all flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
                   style={{
-                    background: 'linear-gradient(135deg, #3b82f6, #2563eb)',
-                    boxShadow: '0 2px 12px rgba(59, 130, 246, 0.4)'
+                    background: 'linear-gradient(135deg, #ea580c, #c2410c)',
+                    boxShadow: '0 2px 12px rgba(234, 88, 12, 0.4)'
                   }}
               >
                 {isLoading ? (
@@ -2439,7 +2439,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                           <Plus className="w-5 h-5 text-green-400" />
                         )}
                         {['github_edit_file', 'github_replace_string'].includes(tool.toolName) && (
-                          <File className="w-5 h-5 text-blue-400" />
+                          <File className="w-5 h-5 text-orange-400" />
                         )}
                         {tool.toolName === 'github_stage_change' && (
                           <GitBranch className="w-5 h-5 text-yellow-400" />
@@ -2755,7 +2755,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
               type="file"
               multiple
               onChange={(e) => handleFileAttach(e.target.files)}
-              className="w-full text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-600 file:text-white hover:file:bg-blue-700 file:cursor-pointer"
+              className="w-full text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-orange-600 file:text-white hover:file:bg-orange-500 file:cursor-pointer"
               accept=".txt,.md,.json,.js,.ts,.tsx,.jsx,.css,.html,.py,.java,.cpp,.c,.go,.rs,.yaml,.yml,.xml,.sh,.bat,.ps1,.sql"
             />
             <p className="text-xs text-gray-500">

--- a/components/workspace/templates-view.tsx
+++ b/components/workspace/templates-view.tsx
@@ -395,8 +395,8 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading templates...</p>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500 mx-auto mb-4"></div>
+          <p className="text-gray-400">Loading templates...</p>
         </div>
       </div>
     )
@@ -405,7 +405,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
   return (
     <div className="h-full overflow-y-auto bg-[#030305]">
       {/* Header Section */}
-      <div className="relative bg-gradient-to-br from-purple-900/30 via-[#030305] to-cyan-900/30 py-12 px-4 sm:px-6 lg:px-8 border-b border-white/5">
+      <div className="relative bg-gradient-to-br from-orange-950/40 via-[#030305] to-gray-900/30 py-12 px-4 sm:px-6 lg:px-8 border-b border-white/5">
         <div className="absolute inset-0 bg-gradient-to-b from-transparent via-black/10 to-black/30"></div>
         
         <div className="relative z-10 max-w-7xl mx-auto">
@@ -425,7 +425,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                 params.set('view', 'template-earnings')
                 window.location.href = `/workspace?${params.toString()}`
               }}
-              className="bg-white/5 hover:bg-white/10 border border-white/10 hover:border-purple-500/50 backdrop-blur-md text-white font-semibold gap-2 whitespace-nowrap transition-all"
+              className="bg-white/5 hover:bg-white/10 border border-white/10 hover:border-orange-500/50 backdrop-blur-md text-white font-semibold gap-2 whitespace-nowrap transition-all"
             >
               <TrendingUp className="h-4 w-4" />
               <span className="hidden sm:inline">My Earnings</span>
@@ -447,7 +447,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
           <AccordionContent className="px-4 sm:px-6 pb-4">
             <div className="space-y-4">
               {/* Currency Indicator */}
-              <div className="flex items-center gap-2 px-3 py-2 bg-white/5 border border-purple-500/30 rounded-lg text-xs text-purple-200 w-fit backdrop-blur-sm">
+              <div className="flex items-center gap-2 px-3 py-2 bg-white/5 border border-orange-500/30 rounded-lg text-xs text-orange-200 w-fit backdrop-blur-sm">
                 <span>
                   💵 Prices in <strong>CAD</strong> • 1 USD = ${exchangeRate.toFixed(2)} CAD
                 </span>
@@ -460,7 +460,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                   placeholder="Search templates by name, description, or creator..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="flex-1 px-4 py-2 rounded-lg bg-[#0d1117] border border-white/10 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50 transition-all"
+                  className="flex-1 px-4 py-2 rounded-lg bg-[#0d1117] border border-white/10 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
                 />
               </div>
 
@@ -468,7 +468,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                 {/* Category Filter */}
                 <Select value={category} onValueChange={setCategory}>
-                  <SelectTrigger className="bg-[#0d1117] border-white/10 text-white hover:border-purple-500/50 transition-all">
+                  <SelectTrigger className="bg-[#0d1117] border-white/10 text-white hover:border-orange-500/50 transition-all">
                     <SelectValue placeholder="Category" />
                   </SelectTrigger>
                   <SelectContent className="bg-[#0d1117] border-white/10">
@@ -484,7 +484,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
 
                 {/* Sort Filter */}
                 <Select value={sortBy} onValueChange={setSortBy}>
-                  <SelectTrigger className="bg-[#0d1117] border-white/10 text-white hover:border-purple-500/50 transition-all">
+                  <SelectTrigger className="bg-[#0d1117] border-white/10 text-white hover:border-orange-500/50 transition-all">
                     <SelectValue placeholder="Sort by" />
                   </SelectTrigger>
                   <SelectContent className="bg-[#0d1117] border-white/10">
@@ -502,7 +502,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                   placeholder="Min price"
                   value={minPrice}
                   onChange={(e) => setMinPrice(Number(e.target.value))}
-                  className="px-3 py-2 rounded-lg bg-[#0d1117] border border-white/10 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50 transition-all"
+                  className="px-3 py-2 rounded-lg bg-[#0d1117] border border-white/10 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
                 />
 
                 {/* Price Range Max */}
@@ -511,7 +511,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                   placeholder="Max price"
                   value={maxPrice}
                   onChange={(e) => setMaxPrice(Number(e.target.value))}
-                  className="px-3 py-2 rounded-lg bg-[#0d1117] border border-white/10 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50 transition-all"
+                  className="px-3 py-2 rounded-lg bg-[#0d1117] border border-white/10 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500/50 transition-all"
                 />
               </div>
 
@@ -547,7 +547,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
               const pricing = templatePricing.get(template.id)
               const reviews = templateReviews.get(template.id) || []
               return (
-                <Card key={template.id} className="bg-[#0d1117] border-white/10 hover:border-purple-500/30 transition-all duration-300 overflow-hidden group relative hover:shadow-lg hover:shadow-purple-500/10">
+                <Card key={template.id} className="bg-[#0d1117] border-white/10 hover:border-orange-500/30 transition-all duration-300 overflow-hidden group relative hover:shadow-lg hover:shadow-orange-500/10">
                   {/* Edit/Delete Icon Buttons (top left) */}
                   {isOwner && (
                     <div className="absolute top-3 left-3 flex gap-2 z-10">
@@ -588,14 +588,14 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                       {pricing.price === 0 ? (
                         <Badge className='bg-green-500/90 text-white'>Free</Badge>
                       ) : (
-                        <Badge className='bg-blue-500/90 text-white'>
+                        <Badge className='bg-orange-500/90 text-white'>
                           {formatPrice(convertUsdToCad(pricing.price, exchangeRate), 'CAD')}
                         </Badge>
                       )}
                     </div>
                   )}
 
-                  <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-purple-900/20 via-[#030305] to-cyan-900/20">
+                  <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-orange-950/20 via-[#030305] to-gray-900/20">
                     {template.thumbnail_url ? (
                       <Image
                         src={template.thumbnail_url}
@@ -635,7 +635,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                       {template.name}
                     </h3>
                     {metadata?.category && (
-                      <Badge variant="outline" className="mb-2 text-xs border-purple-500/30 text-purple-300">{metadata.category}</Badge>
+                      <Badge variant="outline" className="mb-2 text-xs border-orange-500/30 text-orange-300">{metadata.category}</Badge>
                     )}
                     <p className="text-white/60 text-sm line-clamp-2 mb-3">
                       {template.description || 'No description provided'}
@@ -655,7 +655,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                     <div className="flex flex-col gap-2">
                       <Button
                         onClick={() => handlePurchase(template)}
-                        className="w-full bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-700 hover:to-cyan-700 text-white transition-all shadow-lg shadow-purple-500/20"
+                        className="w-full bg-orange-600 hover:bg-orange-500 text-white transition-all shadow-lg shadow-orange-500/20"
                         size="sm"
                       >
                         <ShoppingCart className="h-4 w-4 mr-1" />
@@ -871,7 +871,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
                       href={selectedTemplate.preview_url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-blue-400 underline break-all"
+                      className="text-orange-400 underline break-all"
                     >
                       {selectedTemplate.preview_url}
                     </a>
@@ -937,7 +937,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
               <Button
                 onClick={() => selectedTemplate && handlePurchase(selectedTemplate)}
                 disabled={isUsingTemplate}
-                className="flex-1 bg-blue-600 hover:bg-blue-700"
+                className="flex-1 bg-orange-600 hover:bg-orange-500"
               >
                 <ShoppingCart className="h-4 w-4 mr-1" />
                 {isUsingTemplate ? 'Processing...' : (templatePricing.get(selectedTemplate?.id || '')?.price === 0 ? 'Get Access' : `Purchase - ${formatPrice(convertUsdToCad(templatePricing.get(selectedTemplate?.id || '')?.price || 0, exchangeRate), 'CAD')}`)}
@@ -980,7 +980,7 @@ export function TemplatesView({ userId }: TemplatesViewProps) {
             </Button>
             <Button
               onClick={() => router.push('/auth')}
-              className="bg-blue-600 hover:bg-blue-700"
+              className="bg-orange-600 hover:bg-orange-500"
             >
               Sign In / Sign Up
             </Button>

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -1048,41 +1048,47 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                   <div className="h-full flex flex-col overflow-hidden">
                     {/* Tab Switcher with Preview Controls - Hidden when in preview mode */}
                     {activeTab !== "preview" && (
-                      <div className="border-b border-gray-800/60 bg-gray-900/80 p-2 flex-shrink-0">
+                      <div className="border-b border-gray-800/60 bg-gray-900/80 px-3 py-2 flex-shrink-0">
                         <div className="flex items-center justify-between">
-                          <div className="flex space-x-1">
-                            <Button
-                              variant={activeTab === "code" ? "secondary" : "ghost"}
-                              size="sm"
+                          <div className="flex items-center gap-1">
+                            <button
                               onClick={() => setActiveTab("code")}
                               title="Code Editor"
+                              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                                activeTab === "code" ? "bg-orange-600/15 text-orange-400" : "text-gray-400 hover:text-gray-200 hover:bg-gray-800/60"
+                              }`}
                             >
-                              <Code className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
+                              <Code className="h-3.5 w-3.5" />
+                              <span>Code</span>
+                            </button>
+                            <button
                               onClick={() => setActiveTab("preview")}
                               title="Live Preview"
+                              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 transition-colors"
                             >
-                              <Eye className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant={activeTab === "cloud" ? "secondary" : "ghost"}
-                              size="sm"
+                              <Eye className="h-3.5 w-3.5" />
+                              <span>Preview</span>
+                            </button>
+                            <button
                               onClick={() => setActiveTab("cloud")}
                               title="Cloud Services"
+                              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                                activeTab === "cloud" ? "bg-orange-600/15 text-orange-400" : "text-gray-400 hover:text-gray-200 hover:bg-gray-800/60"
+                              }`}
                             >
-                              <Cloud className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant={activeTab === "audit" ? "secondary" : "ghost"}
-                              size="sm"
+                              <Cloud className="h-3.5 w-3.5" />
+                              <span>Cloud</span>
+                            </button>
+                            <button
                               onClick={() => setActiveTab("audit")}
                               title="Code Audit & Quality"
+                              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                                activeTab === "audit" ? "bg-orange-600/15 text-orange-400" : "text-gray-400 hover:text-gray-200 hover:bg-gray-800/60"
+                              }`}
                             >
-                              <Shield className="h-4 w-4" />
-                            </Button>
+                              <Shield className="h-3.5 w-3.5" />
+                              <span>Audit</span>
+                            </button>
                           </div>
 
 
@@ -1250,7 +1256,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                           return <span className="text-green-600 dark:text-green-400">Connected</span>
                         }
                         if (gitHubConnected) {
-                          return <span className="text-blue-600 dark:text-blue-400">Account Connected</span>
+                          return <span className="text-blue-600 dark:text-orange-400">Account Connected</span>
                         }
                         return <span className="text-gray-500">Not Connected</span>
                       })()}
@@ -1683,47 +1689,47 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                 <button
                   onClick={() => setMobileTab("chat")}
                   className={`flex flex-col items-center justify-center gap-0.5 py-1.5 px-3 rounded-xl transition-all ${
-                    mobileTab === "chat" ? "text-blue-400" : "text-gray-500 hover:text-gray-300"
+                    mobileTab === "chat" ? "text-orange-400" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <MessageSquare className={`h-5 w-5 ${mobileTab === "chat" ? "stroke-[2.5]" : ""}`} />
-                  <span className={`text-[10px] font-medium ${mobileTab === "chat" ? "text-blue-400" : ""}`}>Chat</span>
+                  <span className={`text-[10px] font-medium ${mobileTab === "chat" ? "text-orange-400" : ""}`}>Chat</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("files")}
                   className={`flex flex-col items-center justify-center gap-0.5 py-1.5 px-3 rounded-xl transition-all ${
-                    mobileTab === "files" ? "text-blue-400" : "text-gray-500 hover:text-gray-300"
+                    mobileTab === "files" ? "text-orange-400" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <FileText className={`h-5 w-5 ${mobileTab === "files" ? "stroke-[2.5]" : ""}`} />
-                  <span className={`text-[10px] font-medium ${mobileTab === "files" ? "text-blue-400" : ""}`}>Files</span>
+                  <span className={`text-[10px] font-medium ${mobileTab === "files" ? "text-orange-400" : ""}`}>Files</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("editor")}
                   className={`flex flex-col items-center justify-center gap-0.5 py-1.5 px-3 rounded-xl transition-all ${
-                    mobileTab === "editor" ? "text-blue-400" : "text-gray-500 hover:text-gray-300"
+                    mobileTab === "editor" ? "text-orange-400" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <Code className={`h-5 w-5 ${mobileTab === "editor" ? "stroke-[2.5]" : ""}`} />
-                  <span className={`text-[10px] font-medium ${mobileTab === "editor" ? "text-blue-400" : ""}`}>Editor</span>
+                  <span className={`text-[10px] font-medium ${mobileTab === "editor" ? "text-orange-400" : ""}`}>Editor</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("preview")}
                   className={`flex flex-col items-center justify-center gap-0.5 py-1.5 px-3 rounded-xl transition-all ${
-                    mobileTab === "preview" ? "text-blue-400" : "text-gray-500 hover:text-gray-300"
+                    mobileTab === "preview" ? "text-orange-400" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <Eye className={`h-5 w-5 ${mobileTab === "preview" ? "stroke-[2.5]" : ""}`} />
-                  <span className={`text-[10px] font-medium ${mobileTab === "preview" ? "text-blue-400" : ""}`}>Preview</span>
+                  <span className={`text-[10px] font-medium ${mobileTab === "preview" ? "text-orange-400" : ""}`}>Preview</span>
                 </button>
                 <button
                   onClick={() => setMobileTab("audit")}
                   className={`flex flex-col items-center justify-center gap-0.5 py-1.5 px-3 rounded-xl transition-all ${
-                    mobileTab === "audit" ? "text-blue-400" : "text-gray-500 hover:text-gray-300"
+                    mobileTab === "audit" ? "text-orange-400" : "text-gray-500 hover:text-gray-300"
                   }`}
                 >
                   <Shield className={`h-5 w-5 ${mobileTab === "audit" ? "stroke-[2.5]" : ""}`} />
-                  <span className={`text-[10px] font-medium ${mobileTab === "audit" ? "text-blue-400" : ""}`}>Audit</span>
+                  <span className={`text-[10px] font-medium ${mobileTab === "audit" ? "text-orange-400" : ""}`}>Audit</span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
Replace blue/purple accent colors with orange (bg-orange-600) throughout:
- Scroll-to-bottom button, mobile bottom tab selected state
- PC tab switch buttons, sidebar selected items, project count badge
- Search modal project gradient, header buttons (Backup, Database, Deploy)
- Empty workspace hero gradient, active tab, filter focus ring
- Templates marketplace: header, filters, cards, purchase buttons
- Project grid: hover text, open link, clone button, sign-in CTA
- Repo agent: send button, input border, selectors, history items
- Rename input focus ring in project header

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the workspace accent to orange for a consistent brand look across all views. Visual-only update; no behavior changes.

- **Refactors**
  - Replaced blue/purple accents with orange (bg-orange-600, hover:bg-orange-500, text-orange-400) including gradients and focus rings.
  - Applied across: sidebar selection and project badges; desktop tab switcher and mobile bottom nav; project grid CTAs/hover; repo agent selectors/input/send/history; project header actions (Backup, Database, Deploy) and rename focus; chat scroll-to-bottom.
  - Updated Empty Workspace and Templates marketplace (headers, filters, cards, purchase buttons) to match the new theme.

<sup>Written for commit 2b71794ae42f703cd0093c907e60105f186a1461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

