### PR TITLE
style: redesign template selector to match model selector pattern

### DIFF
--- a/components/ui/model-selector.tsx
+++ b/components/ui/model-selector.tsx
@@ -173,7 +173,7 @@ export function ModelSelector({
                   </div>
                   <div className="flex items-center gap-1.5 ml-2 flex-shrink-0">
                     {!allowed && <Lock className="size-3 text-gray-500" />}
-                    {isSelected && allowed && <Check className="size-4 text-blue-400" />}
+                    {isSelected && allowed && <Check className="size-4 text-orange-400" />}
                   </div>
                 </button>
               )


### PR DESCRIPTION
Replace shadcn Select component with a custom dropdown matching the model selector's clean text + chevron design:
- Plain text trigger with font-medium text-gray-400 + ChevronDown
- Custom absolute-positioned dropdown with bg-gray-900 rounded-xl
- Each option shows name + description with orange check for selected
- Close on outside click via mousedown listener
- Remove unused shadcn Select imports, Zap, Plus, ImageIcon
- Also fix model selector check icon from blue to orange

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the template selector to match the model selector’s text + chevron dropdown, improving consistency and reducing UI complexity. Updated the model selector’s selected check icon to orange for visual alignment.

- **Refactors**
  - Replaced shadcn Select with a custom dropdown (plain text trigger + ChevronDown).
  - Added absolute-positioned dropdown with bg-gray-900 and rounded-xl.
  - Options show name + short description with orange check for the selected item.
  - Close on outside click via a mousedown listener.
  - Removed unused imports (shadcn Select, Zap, Plus, ImageIcon).

<sup>Written for commit e106b821010c47e0d0d6134f691ec26eaa40fa47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

