### PR TITLE
Claude/revert to commit uz9p7

### DIFF
--- a/components/workspace/repo-agent-view.tsx
+++ b/components/workspace/repo-agent-view.tsx
@@ -1872,55 +1872,35 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
   }
 
   return (
-    <div className="repo-agent-container h-screen flex overflow-hidden" style={{
-      background: 'var(--bg, #0a0e14)',
-      color: 'var(--text, #e5e7eb)'
-    }}>
+    <div className="repo-agent-container h-screen flex overflow-hidden bg-gray-950 text-gray-200">
       {/* Chat Panel */}
       <div
-        className="chat-panel flex flex-col"
+        className="chat-panel flex flex-col relative overflow-hidden"
         style={{
           flex: `0 0 ${chatWidth}%`,
-          background: 'linear-gradient(180deg, #0a0e14 0%, #0d1117 100%)',
-          borderRight: '1px solid rgba(59, 131, 246, 0)',
-          boxShadow: '4px 0 40px rgba(0, 0, 0, 0.5)',
-          position: 'relative',
-          minWidth: '320px',
-          overflow: 'hidden'
+          minWidth: '320px'
         }}
       >
         {/* Chat Header */}
-        <div className="chat-header p-5 flex items-center justify-between gap-3" style={{
-          borderBottom: '1px solid rgba(59, 130, 246, 0.1)',
-          fontWeight: '600',
-          fontSize: '1.1em',
-          background: 'linear-gradient(135deg, rgba(17, 24, 39, 0.8), rgba(31, 41, 55, 0.6))',
-          backdropFilter: 'blur(20px)',
-          position: 'relative',
-          overflow: 'hidden'
-        }}>
+        <div className="chat-header px-4 py-3 flex items-center justify-between gap-3 border-b border-gray-700/60 bg-gray-900/80 backdrop-blur-sm font-semibold text-sm">
           <div className="header-left flex items-center gap-3">
             <button
               onClick={handleBackToLanding}
-              className="back-icon w-6 h-6 cursor-pointer text-gray-400 transition-all hover:text-gray-200 hover:translate-x-[-2px]"
+              className="w-6 h-6 cursor-pointer text-gray-400 transition-all hover:text-gray-200 hover:translate-x-[-2px]"
             >
               <ChevronLeft className="w-full h-full" />
             </button>
-            <div className="status-dot w-2 h-2 bg-green-500 rounded-full" style={{
-              animation: 'pulse 2s infinite',
-              boxShadow: '0 0 12px #10b981'
-            }}></div>          </div>
-          <div className="repo-selector flex items-center gap-2">
+            <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
+          </div>
+          <div className="flex items-center gap-2">
             <select
               value={selectedRepo}
               onChange={(e) => setSelectedRepo(e.target.value)}
-              className="selector bg-gray-800/60 border border-orange-500/30 rounded-lg px-3.5 py-2 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-orange-500"
+              className="bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-1.5 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-gray-600 focus:border-gray-600 appearance-none pr-7"
               style={{
-                appearance: 'none',
                 backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239ca3af' d='M6 8.5l-4-4h8l-4 4z'/%3E%3C/svg%3E")`,
                 backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'right 10px center',
-                paddingRight: '30px'
+                backgroundPosition: 'right 8px center'
               }}
             >
               <option value="">Select repository</option>
@@ -1933,13 +1913,11 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
             <select
               value={selectedBranch}
               onChange={(e) => setSelectedBranch(e.target.value)}
-              className="selector bg-gray-800/60 border border-orange-500/30 rounded-lg px-3.5 py-2 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-orange-500"
+              className="bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-1.5 text-gray-200 text-sm cursor-pointer outline-none transition-all hover:border-gray-600 focus:border-gray-600 appearance-none pr-7"
               style={{
-                appearance: 'none',
                 backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239ca3af' d='M6 8.5l-4-4h8l-4 4z'/%3E%3C/svg%3E")`,
                 backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'right 10px center',
-                paddingRight: '30px'
+                backgroundPosition: 'right 8px center'
               }}
               disabled={isLoadingBranches}
             >
@@ -1955,12 +1933,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
         {/* Messages */}
         <div
           ref={chatBodyRef}
-          className="chat-body flex-1 overflow-y-auto p-8 flex flex-col gap-5"
-          style={{
-            background: 'linear-gradient(180deg, #0a0e14 0%, #0d1117 50%, #0a0e14 100%)',
-            position: 'relative',
-            paddingBottom: '160px'
-          }}
+          className="chat-body flex-1 overflow-y-auto p-8 flex flex-col gap-5 bg-gray-950 pb-40"
         >
           {messages.map((message, index) => {
             const isLongMessage = message.isUser && message.content.length > 200
@@ -1972,18 +1945,11 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
             return (
               <div
                 key={message.id}
-                className={`message max-w-[80%] p-4 rounded-2xl leading-relaxed text-sm transition-all relative`}
-                style={{
-                  alignSelf: message.isUser ? 'flex-end' : 'flex-start',
-                  background: message.isUser
-                    ? 'linear-gradient(135deg, #3b82f6, #2563eb)'
-                    : 'transparent',
-                  color: 'white',
-                  borderBottomRightRadius: message.isUser ? '4px' : '16px',
-                  borderBottomLeftRadius: message.isUser ? '16px' : '4px',
-                  boxShadow: message.isUser ? '0 4px 20px rgba(234, 88, 12, 0.15)' : 'none',
-                  animation: 'messageSlide 0.4s ease-out'
-                }}
+                className={`message max-w-[80%] p-4 rounded-2xl leading-relaxed text-sm transition-all relative ${
+                  message.isUser
+                    ? 'self-end bg-orange-600 text-white rounded-br-sm'
+                    : 'self-start bg-transparent text-white rounded-bl-sm'
+                }`}
               >
                 {message.isUser ? (
                   <div className="group">
@@ -2235,98 +2201,50 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
 
       {/* Resizer */}
       <div
-        className="resizer cursor-col-resize transition-all relative"
-        style={{
-          width: '8px',
-          background: 'linear-gradient(to right, rgba(59, 130, 246, 0.1), transparent)'
-        }}
+        className="resizer w-[6px] cursor-col-resize transition-all relative bg-gray-800/60 hover:bg-gray-700/60"
         onMouseDown={handleMouseDown}
       >
-        <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-0.5 h-10 bg-blue-500/30 rounded-sm opacity-0 transition-opacity hover:opacity-100"></div>
+        <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-0.5 h-10 bg-gray-600 rounded-sm opacity-0 transition-opacity hover:opacity-100"></div>
       </div>
 
       {/* Sidebar */}
-      <div className="sidebar flex-1 flex flex-col overflow-hidden" style={{
-        background: 'linear-gradient(180deg, #0a0e14 0%, #0d1117 100%)',
-        borderLeft: '1px solid rgba(59, 130, 246, 0.1)',
-        boxShadow: '-4px 0 40px rgba(0, 0, 0, 0.5)'
-      }}>
+      <div className="sidebar flex-1 flex flex-col overflow-hidden bg-gray-950 border-l border-gray-700/60">
         {/* Sidebar Tabs */}
-        <div className="sidebar-tabs p-5 flex items-center" style={{
-          background: 'linear-gradient(135deg, rgba(17, 24, 39, 0.8), rgba(31, 41, 55, 0.6))',
-          backdropFilter: 'blur(20px)',
-          borderBottom: '1px solid rgba(59, 130, 246, 0.1)',
-          position: 'relative'
-        }}>
-          <div className="tab-buttons flex gap-2 p-1.5 rounded-xl" style={{
-            background: 'rgba(31, 41, 55, 0.6)',
-            border: '1px solid rgba(59, 130, 246, 0.1)'
-          }}>
+        <div className="sidebar-tabs px-4 py-3 flex items-center bg-gray-900/80 backdrop-blur-sm border-b border-gray-700/60">
+          <div className="tab-buttons flex gap-1 p-1 rounded-xl bg-gray-800/60 border border-gray-700/60">
             <button
               onClick={() => setActiveTab('changes')}
-              className={`tab-btn px-5 py-2.5 text-sm font-medium rounded-lg cursor-pointer transition-all relative ${activeTab === 'changes'
-                ? 'text-white'
-                : 'text-gray-400 hover:text-white'
+              className={`px-4 py-2 text-xs font-medium rounded-lg cursor-pointer transition-all ${activeTab === 'changes'
+                ? 'bg-orange-600/15 text-orange-400'
+                : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/60'
                 }`}
-              style={{
-                background: activeTab === 'changes'
-                  ? 'linear-gradient(135deg, #1e40af, #1d4ed8)'
-                  : 'transparent',
-                boxShadow: activeTab === 'changes'
-                  ? '0 4px 16px rgba(30, 64, 175, 0.5), 0 0 30px rgba(30, 64, 175, 0.2)'
-                  : 'none'
-              }}
             >
               File Changes
             </button>
             <button
               onClick={() => setActiveTab('diffs')}
-              className={`tab-btn px-5 py-2.5 text-sm font-medium rounded-lg cursor-pointer transition-all relative ${activeTab === 'diffs'
-                ? 'text-white'
-                : 'text-gray-400 hover:text-white'
+              className={`px-4 py-2 text-xs font-medium rounded-lg cursor-pointer transition-all ${activeTab === 'diffs'
+                ? 'bg-orange-600/15 text-orange-400'
+                : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/60'
                 }`}
-              style={{
-                background: activeTab === 'diffs'
-                  ? 'linear-gradient(135deg, #1e40af, #1d4ed8)'
-                  : 'transparent',
-                boxShadow: activeTab === 'diffs'
-                  ? '0 4px 16px rgba(30, 64, 175, 0.5), 0 0 30px rgba(30, 64, 175, 0.2)'
-                  : 'none'
-              }}
             >
               Code Diffs
             </button>
             <button
               onClick={() => setActiveTab('actions')}
-              className={`tab-btn px-5 py-2.5 text-sm font-medium rounded-lg cursor-pointer transition-all relative ${activeTab === 'actions'
-                ? 'text-white'
-                : 'text-gray-400 hover:text-white'
+              className={`px-4 py-2 text-xs font-medium rounded-lg cursor-pointer transition-all ${activeTab === 'actions'
+                ? 'bg-orange-600/15 text-orange-400'
+                : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/60'
                 }`}
-              style={{
-                background: activeTab === 'actions'
-                  ? 'linear-gradient(135deg, #1e40af, #1d4ed8)'
-                  : 'transparent',
-                boxShadow: activeTab === 'actions'
-                  ? '0 4px 16px rgba(30, 64, 175, 0.5), 0 0 30px rgba(30, 64, 175, 0.2)'
-                  : 'none'
-              }}
             >
               Actions
             </button>
             <button
               onClick={() => setActiveTab('todos')}
-              className={`tab-btn px-5 py-2.5 text-sm font-medium rounded-lg cursor-pointer transition-all relative ${activeTab === 'todos'
-                ? 'text-white'
-                : 'text-gray-400 hover:text-white'
+              className={`px-4 py-2 text-xs font-medium rounded-lg cursor-pointer transition-all ${activeTab === 'todos'
+                ? 'bg-orange-600/15 text-orange-400'
+                : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/60'
                 }`}
-              style={{
-                background: activeTab === 'todos'
-                  ? 'linear-gradient(135deg, #1e40af, #1d4ed8)'
-                  : 'transparent',
-                boxShadow: activeTab === 'todos'
-                  ? '0 4px 16px rgba(30, 64, 175, 0.5), 0 0 30px rgba(30, 64, 175, 0.2)'
-                  : 'none'
-              }}
             >
               Todos
             </button>
@@ -2334,72 +2252,43 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
         </div>
 
         {/* Tab Content */}
-        <div className="tab-content-wrapper flex-1 overflow-y-auto p-6" style={{
-          background: '#0a0e14'
-        }}>
+        <div className="tab-content-wrapper flex-1 overflow-y-auto p-6 bg-gray-950">
           {activeTab === 'changes' && (
             <div className="tab-content">
-              <h3 className="section-title text-xl font-semibold mb-6 text-white flex items-center gap-3" style={{
-                position: 'relative'
-              }}>
-                <span style={{
-                  content: '""',
-                  width: '4px',
-                  height: '24px',
-                  background: 'linear-gradient(180deg, #3b82f6, #2563eb)',
-                  borderRadius: '2px',
-                  boxShadow: '0 0 12px rgba(59, 130, 246, 0.5)',
-                  display: 'inline-block',
-                  marginRight: '8px'
-                }}></span>
+              <h3 className="text-sm font-semibold mb-4 text-gray-200 flex items-center gap-2">
+                <span className="w-1 h-5 bg-orange-500 rounded-sm inline-block"></span>
                 Files Modified
               </h3>
 
               {messages.flatMap((msg: Message) => msg.toolInvocations?.filter((t: any) => t.state === 'result' && ['github_write_file', 'github_edit_file', 'github_replace_string', 'github_delete_file', 'github_stage_change'].includes(t.toolName)) || []).length === 0 ? (
-                <div className="text-center py-12 text-gray-400">
-                  <File className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                  <p>No file changes yet</p>
+                <div className="text-center py-12 text-gray-500">
+                  <File className="w-10 h-10 mx-auto mb-3 opacity-40" />
+                  <p className="text-sm">No file changes yet</p>
                 </div>
               ) : (
                 messages.flatMap((msg: Message) => msg.toolInvocations?.filter((t: any) => t.state === 'result' && ['github_write_file', 'github_edit_file', 'github_replace_string', 'github_delete_file', 'github_stage_change'].includes(t.toolName)) || []).map((tool: any, index: number) => (
                   <div
                     key={index}
-                    className="file-item flex items-center justify-between p-4.5 mb-3 rounded-xl cursor-pointer transition-all"
-                    style={{
-                      background: 'rgba(31, 41, 55, 0.4)',
-                      border: '1px solid rgba(59, 130, 246, 0.2)'
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.transform = 'translateX(4px)'
-                      e.currentTarget.style.background = 'rgba(31, 41, 55, 0.6)'
-                      e.currentTarget.style.borderColor = 'rgba(59, 130, 246, 0.4)'
-                      e.currentTarget.style.boxShadow = '0 4px 20px rgba(0, 0, 0, 0.3)'
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.transform = 'translateX(0)'
-                      e.currentTarget.style.background = 'rgba(31, 41, 55, 0.4)'
-                      e.currentTarget.style.borderColor = 'rgba(59, 130, 246, 0.2)'
-                      e.currentTarget.style.boxShadow = 'none'
-                    }}
+                    className="flex items-center justify-between p-3 mb-2 rounded-xl cursor-pointer transition-all bg-gray-900/60 border border-gray-700/60 hover:bg-gray-800/60 hover:border-gray-600/60"
                   >
                     <div className="flex items-center">
-                      <div className="file-icon mr-3">
+                      <div className="mr-3">
                         {tool.toolName === 'github_delete_file' && (
-                          <Minus className="w-5 h-5 text-red-400" />
+                          <Minus className="w-4 h-4 text-red-400" />
                         )}
                         {tool.toolName === 'github_write_file' && (
-                          <Plus className="w-5 h-5 text-green-400" />
+                          <Plus className="w-4 h-4 text-green-400" />
                         )}
                         {['github_edit_file', 'github_replace_string'].includes(tool.toolName) && (
-                          <File className="w-5 h-5 text-orange-400" />
+                          <File className="w-4 h-4 text-orange-400" />
                         )}
                         {tool.toolName === 'github_stage_change' && (
-                          <GitBranch className="w-5 h-5 text-yellow-400" />
+                          <GitBranch className="w-4 h-4 text-yellow-400" />
                         )}
                       </div>
                       <div>
-                        <div className="font-medium text-white">{tool.args?.path || tool.args?.filePath || 'unknown'}</div>
-                        <div className="text-green-400 text-sm mt-1">
+                        <div className="text-sm font-medium text-gray-200">{tool.args?.path || tool.args?.filePath || 'unknown'}</div>
+                        <div className="text-green-400 text-xs mt-0.5">
                           {tool.toolName === 'github_write_file' && 'created'}
                           {['github_edit_file', 'github_replace_string'].includes(tool.toolName) && 'modified'}
                           {tool.toolName === 'github_delete_file' && 'deleted'}
@@ -2415,26 +2304,15 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
 
           {activeTab === 'diffs' && (
             <div className="tab-content">
-              <h3 className="section-title text-xl font-semibold mb-6 text-white flex items-center gap-3" style={{
-                position: 'relative'
-              }}>
-                <span style={{
-                  content: '""',
-                  width: '4px',
-                  height: '24px',
-                  background: 'linear-gradient(180deg, #3b82f6, #2563eb)',
-                  borderRadius: '2px',
-                  boxShadow: '0 0 12px rgba(59, 130, 246, 0.5)',
-                  display: 'inline-block',
-                  marginRight: '8px'
-                }}></span>
+              <h3 className="text-sm font-semibold mb-4 text-gray-200 flex items-center gap-2">
+                <span className="w-1 h-5 bg-orange-500 rounded-sm inline-block"></span>
                 Review Changes
               </h3>
 
               {messages.flatMap((msg: Message) => msg.toolInvocations?.filter((t: any) => t.state === 'result' && ['github_write_file', 'github_edit_file', 'github_replace_string', 'github_delete_file', 'github_stage_change'].includes(t.toolName)) || []).length === 0 ? (
-                <div className="text-center py-12 text-gray-400">
-                  <Code className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                  <p>No diffs to review</p>
+                <div className="text-center py-12 text-gray-500">
+                  <Code className="w-10 h-10 mx-auto mb-3 opacity-40" />
+                  <p className="text-sm">No diffs to review</p>
                 </div>
               ) : (
                 messages.flatMap((msg: Message) => msg.toolInvocations?.filter((t: any) => t.state === 'result' && ['github_write_file', 'github_edit_file', 'github_replace_string', 'github_delete_file', 'github_stage_change'].includes(t.toolName)) || []).map((change: any, index: number) => {
@@ -2461,25 +2339,11 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                   return (
                     <div
                       key={index}
-                      className="accordion overflow-hidden mb-5 rounded-xl"
-                      style={{
-                        background: 'rgba(31, 41, 55, 0.4)',
-                        border: '1px solid rgba(59, 130, 246, 0.2)',
-                        boxShadow: '0 4px 16px rgba(0, 0, 0, 0.3)'
-                      }}
+                      className="overflow-hidden mb-3 rounded-xl bg-gray-900/60 border border-gray-700/60"
                     >
                       <button
                         onClick={() => toggleDiff(filePath)}
-                        className="accordion-header w-full p-4 font-medium text-white flex items-center justify-between gap-2.5 cursor-pointer transition-all"
-                        style={{
-                          background: 'linear-gradient(135deg, #1e40af, #1d4ed8)'
-                        }}
-                        onMouseEnter={(e) => {
-                          e.currentTarget.style.background = 'linear-gradient(135deg, #2563eb, #1d4ed8)'
-                        }}
-                        onMouseLeave={(e) => {
-                          e.currentTarget.style.background = 'linear-gradient(135deg, #1e40af, #1d4ed8)'
-                        }}
+                        className="w-full p-3 text-sm font-medium text-gray-200 flex items-center justify-between gap-2.5 cursor-pointer transition-all bg-gray-800/60 hover:bg-gray-800"
                       >
                         <div className="file-info flex items-center gap-2.5 flex-1">
                           <File className="w-4 h-4" />
@@ -2525,7 +2389,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                                   key={lineIndex}
                                   className="diff-line text-xs font-mono whitespace-pre-wrap break-all transition-all p-2 rounded"
                                   style={{
-                                    background: line.startsWith('+') ? 'rgba(34, 197, 94, 0.1)' : line.startsWith('-') ? 'rgba(239, 68, 68, 0.1)' : 'rgba(59, 130, 246, 0.05)',
+                                    background: line.startsWith('+') ? 'rgba(34, 197, 94, 0.1)' : line.startsWith('-') ? 'rgba(239, 68, 68, 0.1)' : 'rgba(107, 114, 128, 0.05)',
                                     borderLeft: line.startsWith('+') ? '3px solid #22c55e' : line.startsWith('-') ? '3px solid #ef4444' : 'transparent',
                                     color: line.startsWith('+') ? '#86efac' : line.startsWith('-') ? '#fca5a5' : '#9ca3af'
                                   }}
@@ -2546,54 +2410,29 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
 
           {activeTab === 'actions' && (
             <div className="tab-content">
-              <h3 className="section-title text-xl font-semibold mb-6 text-white flex items-center gap-3" style={{
-                position: 'relative'
-              }}>
-                <span style={{
-                  content: '""',
-                  width: '4px',
-                  height: '24px',
-                  background: 'linear-gradient(180deg, #3b82f6, #2563eb)',
-                  borderRadius: '2px',
-                  boxShadow: '0 0 12px rgba(59, 130, 246, 0.5)',
-                  display: 'inline-block',
-                  marginRight: '8px'
-                }}></span>
+              <h3 className="text-sm font-semibold mb-4 text-gray-200 flex items-center gap-2">
+                <span className="w-1 h-5 bg-orange-500 rounded-sm inline-block"></span>
                 Actions Performed
               </h3>
 
               {actionLogs.length === 0 ? (
-                <div className="text-center py-12 text-gray-400">
-                  <CheckCircle2 className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                  <p>No actions performed yet</p>
+                <div className="text-center py-12 text-gray-500">
+                  <CheckCircle2 className="w-10 h-10 mx-auto mb-3 opacity-40" />
+                  <p className="text-sm">No actions performed yet</p>
                 </div>
               ) : (
                 actionLogs.map((action) => (
                   <div
                     key={action.id}
-                    className="action-item flex items-center gap-4 p-4.5 mb-3 rounded-xl transition-all"
-                    style={{
-                      background: 'rgba(31, 41, 55, 0.4)',
-                      border: '1px solid rgba(59, 130, 246, 0.2)'
-                    }}
-                    onMouseEnter={(e) => {
-                      e.currentTarget.style.transform = 'translateX(4px)'
-                      e.currentTarget.style.background = 'rgba(31, 41, 55, 0.6)'
-                      e.currentTarget.style.borderColor = 'rgba(59, 130, 246, 0.4)'
-                    }}
-                    onMouseLeave={(e) => {
-                      e.currentTarget.style.transform = 'translateX(0)'
-                      e.currentTarget.style.background = 'rgba(31, 41, 55, 0.4)'
-                      e.currentTarget.style.borderColor = 'rgba(59, 130, 246, 0.2)'
-                    }}
+                    className="flex items-center gap-3 p-3 mb-2 rounded-xl transition-all bg-gray-900/60 border border-gray-700/60 hover:bg-gray-800/60 hover:border-gray-600/60"
                   >
                     <div className="text-green-400">
-                      <CheckCircle2 className="w-5 h-5" />
+                      <CheckCircle2 className="w-4 h-4" />
                     </div>
                     <div className="flex-1">
-                      <div className="font-medium text-white">{action.description}</div>
-                      <div className="text-gray-500 text-xs mt-1 flex items-center gap-2">
-                        <span className="px-2 py-1 bg-gray-700 rounded text-gray-300">
+                      <div className="text-sm font-medium text-gray-200">{action.description}</div>
+                      <div className="text-gray-500 text-xs mt-0.5 flex items-center gap-2">
+                        <span className="px-1.5 py-0.5 bg-gray-800 rounded text-gray-400 text-[10px]">
                           {action.type === 'file_operation' && 'File'}
                           {action.type === 'api_call' && 'API'}
                           {action.type === 'commit' && 'Commit'}
@@ -2610,27 +2449,16 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
 
           {activeTab === 'todos' && (
             <div className="tab-content">
-              <h3 className="section-title text-xl font-semibold mb-6 text-white flex items-center gap-3" style={{
-                position: 'relative'
-              }}>
-                <span style={{
-                  content: '""',
-                  width: '4px',
-                  height: '24px',
-                  background: 'linear-gradient(180deg, #3b82f6, #2563eb)',
-                  borderRadius: '2px',
-                  boxShadow: '0 0 12px rgba(59, 130, 246, 0.5)',
-                  display: 'inline-block',
-                  marginRight: '8px'
-                }}></span>
+              <h3 className="text-sm font-semibold mb-4 text-gray-200 flex items-center gap-2">
+                <span className="w-1 h-5 bg-orange-500 rounded-sm inline-block"></span>
                 Todo List
               </h3>
 
               {todos.length === 0 ? (
-                <div className="text-center py-12 text-gray-400">
-                  <CheckCircle2 className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                  <p>No todos yet</p>
-                  <p className="text-sm mt-2">Ask me to create a todo and I'll add it here!</p>
+                <div className="text-center py-12 text-gray-500">
+                  <CheckCircle2 className="w-10 h-10 mx-auto mb-3 opacity-40" />
+                  <p className="text-sm">No todos yet</p>
+                  <p className="text-xs mt-1.5 text-gray-600">Ask me to create a todo and I'll add it here!</p>
                 </div>
               ) : (
                 <Queue>
@@ -2681,16 +2509,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
         </div>
       </div>
 
-      <style jsx>{`
-        @keyframes pulse {
-          0%, 100% { opacity: 0.6; transform: scale(1); }
-          50% { opacity: 1; transform: scale(1.3); }
-        }
-        @keyframes messageSlide {
-          from { opacity: 0; transform: translateY(20px); }
-          to { opacity: 1; transform: translateY(0); }
-        }
-      `}</style>
+      {/* Animations handled via Tailwind */}
 
       {/* File Upload Dialog */}
       <Dialog open={showFileDialog} onOpenChange={setShowFileDialog}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restyled the Repo Agent landing and workspace to match chat-panel-v2 and the orange dark theme, replacing gradient-heavy inline styles with Tailwind. This makes the UI consistent, lighter, and easier to maintain.

- **Refactors**
  - Removed inline CSS; standardized bg-gray-950/900/800 with orange accents across header, messages, sidebar, diffs, actions, todos, and resizer.
  - Rebuilt landing and chat input as rounded cards with compact action bars; ArrowUp send and Square stop; auto-resizing textarea; Enter to send.
  - Simplified landing header (GitHub connect, repo/branch selects) and restyled history dropdown; switched some Button/Textarea to native elements.
  - Streamlined message bubbles and attachment chips; added clear chat and attachment Popover with consistent icons and hover states.
  - Converted file change items and diff accordions to clean cards; updated tabs to orange-focused style.
  - Visual-only refactor; no behavior changes.

<sup>Written for commit 15c4e9dd2d176e8069a3f3cf4c0b3e41889c7f60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

