### PR TITLE
fix: conversation history bug + rebrand sidebar, modals, code editor

### DIFF
--- a/components/workspace/code-editor.tsx
+++ b/components/workspace/code-editor.tsx
@@ -254,7 +254,7 @@ function InlineChat({
           <Button 
             size="sm" 
             onClick={handleApplyFix} 
-            className="h-6 px-2 text-xs bg-blue-600 hover:bg-blue-700 text-white border-0 rounded"
+            className="h-6 px-2 text-xs bg-orange-600 hover:bg-orange-500 text-white border-0 rounded"
           >
             Accept
           </Button>
@@ -317,7 +317,7 @@ function InlineChat({
               size="sm" 
               onClick={handleSubmit}
               disabled={!input.trim() || isLoading}
-              className="h-5 px-2 text-[10px] bg-blue-600 hover:bg-blue-700 text-white border-0 rounded"
+              className="h-5 px-2 text-[10px] bg-orange-600 hover:bg-orange-500 text-white border-0 rounded"
             >
               Send
             </Button>
@@ -993,27 +993,27 @@ export function CodeEditor({ file, onSave, projectFiles = [] }: CodeEditorProps)
       <style dangerouslySetInnerHTML={{
         __html: `
           .inline-streaming-area {
-            background-color: rgba(59, 130, 246, 0.1) !important;
-            border-left: 3px solid #3b82f6 !important;
+            background-color: rgba(249, 115, 22, 0.1) !important;
+            border-left: 3px solid #f97316 !important;
           }
-          
+
           .inline-streaming-line-decoration {
-            background: linear-gradient(90deg, 
-              rgba(59, 130, 246, 0.2) 0%, 
-              rgba(59, 130, 246, 0.1) 50%, 
+            background: linear-gradient(90deg,
+              rgba(249, 115, 22, 0.2) 0%,
+              rgba(249, 115, 22, 0.1) 50%,
               transparent 100%
             ) !important;
           }
-          
+
           .inline-streaming-cursor {
             position: relative !important;
           }
-          
+
           .inline-streaming-cursor-line {
-            background: linear-gradient(90deg, 
-              #3b82f6 0%, 
-              #60a5fa 50%, 
-              #93c5fd 100%
+            background: linear-gradient(90deg,
+              #f97316 0%,
+              #fb923c 50%,
+              #fdba74 100%
             ) !important;
             animation: streaming-pulse 1.5s ease-in-out infinite !important;
             border-radius: 2px !important;
@@ -1038,7 +1038,7 @@ export function CodeEditor({ file, onSave, projectFiles = [] }: CodeEditorProps)
             top: 0;
             bottom: 0;
             width: 2px;
-            background: #3b82f6;
+            background: #f97316;
             animation: streaming-cursor 1s ease-in-out infinite;
             z-index: 10;
           }
@@ -1058,7 +1058,7 @@ export function CodeEditor({ file, onSave, projectFiles = [] }: CodeEditorProps)
         <div className="flex items-center space-x-2">
           <FileText className="h-4 w-4 text-gray-500" />
           <span className="text-sm font-medium text-gray-200">{file.name}</span>
-          {hasChanges && <div className="w-2 h-2 bg-blue-500 rounded-full" />}
+          {hasChanges && <div className="w-2 h-2 bg-orange-500 rounded-full" />}
         </div>
         <div className="flex items-center space-x-2">
           <Button 
@@ -1086,9 +1086,9 @@ export function CodeEditor({ file, onSave, projectFiles = [] }: CodeEditorProps)
             <Sparkles className="h-4 w-4" />
           </Button>
           {isInlineStreaming && (
-            <div className="flex items-center space-x-2 px-2 py-1 bg-blue-100 dark:bg-blue-900 rounded-md">
-              <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
-              <span className="text-xs text-blue-700 dark:text-blue-300">
+            <div className="flex items-center space-x-2 px-2 py-1 bg-orange-500/10 rounded-md">
+              <div className="w-2 h-2 bg-orange-500 rounded-full animate-pulse"></div>
+              <span className="text-xs text-orange-400">
                 AI Streaming
                 {streamingEditMode === 'search_replace' && ' (Targeted Edit)'}
                 {streamingEditMode === 'full_file' && ' (Full File)'}

--- a/components/workspace/modern-sidebar.tsx
+++ b/components/workspace/modern-sidebar.tsx
@@ -198,11 +198,11 @@ export function ModernSidebar({
                 <AccordionTrigger className="py-2 px-2 hover:no-underline hover:bg-gray-800 rounded-md transition-colors">
                   <div className="flex items-center justify-between w-full">
                     <div className="flex items-center gap-2">
-                      <Coins className="h-4 w-4 text-green-400" />
+                      <Coins className="h-4 w-4 text-orange-400" />
                       <span className="text-sm text-gray-400">Credits</span>
                     </div>
                     {!loadingCredits && creditBalance !== null && (
-                      <span className="text-xs font-bold text-green-400 mr-2">
+                      <span className="text-xs font-bold text-orange-400 mr-2">
                         {creditBalance.toFixed(2)}
                       </span>
                     )}
@@ -214,12 +214,12 @@ export function ModernSidebar({
                       <>
                         <div className="flex items-center justify-between text-xs">
                           <span className="text-gray-400">~{estimatedMessages} messages</span>
-                          <span className="text-green-400 capitalize">{currentPlan}</span>
+                          <span className="text-orange-400 capitalize">{currentPlan}</span>
                         </div>
                         
                         <div className="flex items-center gap-2">
                           {creditBalance > 10 ? (
-                            <div className="flex items-center gap-1 text-green-400">
+                            <div className="flex items-center gap-1 text-orange-400">
                               <TrendingUp className="h-3 w-3" />
                               <span className="text-xs">Good balance</span>
                             </div>
@@ -238,7 +238,7 @@ export function ModernSidebar({
 
                         <Button
                           size="sm"
-                          className="w-full h-8 text-xs bg-green-600 hover:bg-green-700"
+                          className="w-full h-8 text-xs bg-orange-600 hover:bg-orange-500"
                           onClick={() => handleNavigation('/pricing')}
                         >
                           <CreditCard className="h-3 w-3 mr-1" />
@@ -389,7 +389,7 @@ export function ModernSidebar({
             <button 
               className={`flex items-center w-full h-10 px-2 ${shouldExpand ? 'justify-start' : 'justify-center'} hover:bg-gray-800 rounded-md transition-colors`}
             >
-              <div className="w-8 h-8 bg-pink-600 rounded-full flex items-center justify-center flex-shrink-0">
+              <div className="w-8 h-8 bg-orange-600 rounded-full flex items-center justify-center flex-shrink-0">
                 <span className="text-white text-xs font-bold">
                   {user.email?.charAt(0).toUpperCase() || 'A'}
                 </span>

--- a/components/workspace/pc-workspace-layout.tsx
+++ b/components/workspace/pc-workspace-layout.tsx
@@ -1684,45 +1684,47 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
       {/* Create Project Dialog - available for both desktop and mobile */}
       <Dialog open={isCreateDialogOpen} onOpenChange={handleModalClose}>
-        <DialogContent className="z-[100]">
+        <DialogContent className="z-[100] bg-gray-900 border-gray-800 text-white">
           <DialogHeader>
-            <DialogTitle>Create New Project</DialogTitle>
-            <DialogDescription>Start building your next app with AI assistance.</DialogDescription>
+            <DialogTitle className="text-white">Create New Project</DialogTitle>
+            <DialogDescription className="text-gray-400">Start building your next app with AI assistance.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <Label htmlFor="project-name">Project Name</Label>
+              <Label htmlFor="project-name" className="text-gray-300">Project Name</Label>
               <Input
                 id="project-name"
                 placeholder="My Awesome App"
                 value={newProjectName}
                 onChange={(e) => setNewProjectName(e.target.value)}
+                className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
               />
             </div>
             <div>
-              <Label htmlFor="project-description">Description (Optional)</Label>
+              <Label htmlFor="project-description" className="text-gray-300">Description (Optional)</Label>
               <Textarea
                 id="project-description"
                 placeholder="Describe what your app will do..."
                 value={newProjectDescription}
                 onChange={(e) => setNewProjectDescription(e.target.value)}
+                className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
               />
             </div>
             <div>
-              <Label htmlFor="template">Template</Label>
+              <Label htmlFor="template" className="text-gray-300">Template</Label>
               <Select value={selectedTemplate} onValueChange={(value: 'vite-react' | 'nextjs') => setSelectedTemplate(value)}>
-                <SelectTrigger id="template">
+                <SelectTrigger id="template" className="bg-gray-800 border-gray-700 text-white">
                   <SelectValue placeholder="Select a template..." />
                 </SelectTrigger>
-                <SelectContent className="z-[110]">
-                  <SelectItem value="vite-react">Vite</SelectItem>
-                  <SelectItem value="nextjs">Next.js</SelectItem>
+                <SelectContent className="z-[110] bg-gray-800 border-gray-700">
+                  <SelectItem value="vite-react" className="text-gray-200 hover:bg-gray-700">Vite</SelectItem>
+                  <SelectItem value="nextjs" className="text-gray-200 hover:bg-gray-700">Next.js</SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </div>
           <DialogFooter>
-            <Button onClick={handleCreateProject} disabled={!newProjectName.trim() || isCreating}>
+            <Button onClick={handleCreateProject} disabled={!newProjectName.trim() || isCreating} className="bg-orange-600 hover:bg-orange-500 text-white">
               {isCreating ? "Creating..." : "Create Project"}
             </Button>
           </DialogFooter>

--- a/components/workspace/project-header.tsx
+++ b/components/workspace/project-header.tsx
@@ -387,47 +387,49 @@ export function ProjectHeader({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          <DialogContent className="z-50">
+          <DialogContent className="z-50 bg-gray-900 border-gray-800 text-white">
             <DialogHeader>
-              <DialogTitle>Create New Project</DialogTitle>
-              <DialogDescription>Start building your next app with AI assistance.</DialogDescription>
+              <DialogTitle className="text-white">Create New Project</DialogTitle>
+              <DialogDescription className="text-gray-400">Start building your next app with AI assistance.</DialogDescription>
             </DialogHeader>
             <div className="space-y-4">
               <div>
-                <Label htmlFor="name">Project Name</Label>
+                <Label htmlFor="name" className="text-gray-300">Project Name</Label>
                 <Input
                   id="name"
                   placeholder="My Awesome App"
                   value={newProjectName}
                   onChange={(e) => setNewProjectName(e.target.value)}
+                  className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
                 />
               </div>
               <div>
-                <Label htmlFor="description">Description (Optional)</Label>
+                <Label htmlFor="description" className="text-gray-300">Description (Optional)</Label>
                 <Textarea
                   id="description"
                   placeholder="Describe what your app will do..."
                   value={newProjectDescription}
                   onChange={(e) => setNewProjectDescription(e.target.value)}
+                  className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
                 />
               </div>
               <div>
-                <Label htmlFor="template">Template</Label>
+                <Label htmlFor="template" className="text-gray-300">Template</Label>
                 <Select value={selectedTemplate} onValueChange={(value: 'vite-react' | 'nextjs' | 'expo' | 'html') => setSelectedTemplate(value)}>
-                  <SelectTrigger id="template">
+                  <SelectTrigger id="template" className="bg-gray-800 border-gray-700 text-white">
                     <SelectValue placeholder="Select a template..." />
                   </SelectTrigger>
-                  <SelectContent className="z-[110]">
-                    <SelectItem value="vite-react">Vite</SelectItem>
-                    <SelectItem value="nextjs">Next.js</SelectItem>
-                    <SelectItem value="expo">Expo (Mobile)</SelectItem>
-                    <SelectItem value="html">HTML</SelectItem>
+                  <SelectContent className="z-[110] bg-gray-800 border-gray-700">
+                    <SelectItem value="vite-react" className="text-gray-200 hover:bg-gray-700">Vite</SelectItem>
+                    <SelectItem value="nextjs" className="text-gray-200 hover:bg-gray-700">Next.js</SelectItem>
+                    <SelectItem value="expo" className="text-gray-200 hover:bg-gray-700">Expo (Mobile)</SelectItem>
+                    <SelectItem value="html" className="text-gray-200 hover:bg-gray-700">HTML</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
               </div>
             <DialogFooter>
-              <Button onClick={handleCreateProject} disabled={!newProjectName.trim() || isCreating}>
+              <Button onClick={handleCreateProject} disabled={!newProjectName.trim() || isCreating} className="bg-orange-600 hover:bg-orange-500 text-white">
                 {isCreating ? "Creating..." : "Create Project"}
               </Button>
             </DialogFooter>

--- a/components/workspace/repo-agent-view.tsx
+++ b/components/workspace/repo-agent-view.tsx
@@ -536,11 +536,6 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
 
   // Load conversations list on mount
   useEffect(() => {
-    loadConversationsList()
-  }, [userId])
-
-  // Load conversations list on mount
-  useEffect(() => {
     if (userId) {
       loadConversationsList()
     }
@@ -1379,6 +1374,8 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
         setConversationId(newConversation.id)
         console.log('[RepoAgent] Created new conversation:', newConversation.id)
       }
+      // Refresh conversation list so history dropdown stays up to date
+      await loadConversationsList()
     } catch (error) {
       console.error('[RepoAgent] Error saving conversation:', error)
     }

--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -1739,47 +1739,49 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
 
       {/* Create Project Dialog - available for both desktop and mobile */}
       <Dialog open={isCreateDialogOpen} onOpenChange={handleModalClose}>
-        <DialogContent className="z-[100]">
+        <DialogContent className="z-[100] bg-gray-900 border-gray-800 text-white">
           <DialogHeader>
-            <DialogTitle>Create New Project</DialogTitle>
-            <DialogDescription>Start building your next app with AI assistance.</DialogDescription>
+            <DialogTitle className="text-white">Create New Project</DialogTitle>
+            <DialogDescription className="text-gray-400">Start building your next app with AI assistance.</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <Label htmlFor="project-name">Project Name</Label>
+              <Label htmlFor="project-name" className="text-gray-300">Project Name</Label>
               <Input
                 id="project-name"
                 placeholder="My Awesome App"
                 value={newProjectName}
                 onChange={(e) => setNewProjectName(e.target.value)}
+                className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
               />
             </div>
             <div>
-              <Label htmlFor="project-description">Description (Optional)</Label>
+              <Label htmlFor="project-description" className="text-gray-300">Description (Optional)</Label>
               <Textarea
                 id="project-description"
                 placeholder="Describe what your app will do..."
                 value={newProjectDescription}
                 onChange={(e) => setNewProjectDescription(e.target.value)}
+                className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
               />
             </div>
             <div>
-              <Label htmlFor="template">Template</Label>
+              <Label htmlFor="template" className="text-gray-300">Template</Label>
               <Select value={selectedTemplate} onValueChange={(value: 'vite-react' | 'nextjs' | 'expo' | 'html') => setSelectedTemplate(value)}>
-                <SelectTrigger id="template">
+                <SelectTrigger id="template" className="bg-gray-800 border-gray-700 text-white">
                   <SelectValue placeholder="Select a template..." />
                 </SelectTrigger>
-                <SelectContent className="z-[110]">
-                  <SelectItem value="vite-react">Vite</SelectItem>
-                  <SelectItem value="nextjs">Next.js</SelectItem>
-                  <SelectItem value="expo">Expo (Mobile)</SelectItem>
-                  <SelectItem value="html">HTML</SelectItem>
+                <SelectContent className="z-[110] bg-gray-800 border-gray-700">
+                  <SelectItem value="vite-react" className="text-gray-200 hover:bg-gray-700">Vite</SelectItem>
+                  <SelectItem value="nextjs" className="text-gray-200 hover:bg-gray-700">Next.js</SelectItem>
+                  <SelectItem value="expo" className="text-gray-200 hover:bg-gray-700">Expo (Mobile)</SelectItem>
+                  <SelectItem value="html" className="text-gray-200 hover:bg-gray-700">HTML</SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </div>
           <DialogFooter>
-            <Button onClick={handleCreateProject} disabled={!newProjectName.trim() || isCreating}>
+            <Button onClick={handleCreateProject} disabled={!newProjectName.trim() || isCreating} className="bg-orange-600 hover:bg-orange-500 text-white">
               {isCreating ? "Creating..." : "Create Project"}
             </Button>
           </DialogFooter>


### PR DESCRIPTION
- Fix conversation history always empty: call loadConversationsList() after saveConversationToStorage() and remove duplicate useEffect
- Rebrand modern-sidebar: pink avatar -> orange, green credits -> orange
- Style create project modals in project-header, workspace-layout, and pc-workspace-layout with dark theme + orange accent buttons
- Replace all blue colors in code-editor streaming UI with orange

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty conversation history by refreshing the list after saving. Rebrands the sidebar, create-project modals, and code editor to a dark theme with orange accents.

- **Bug Fixes**
  - Call loadConversationsList() after saveConversationToStorage() so the history dropdown updates immediately.
  - Remove duplicate useEffect and keep a single loader keyed to userId.

- **Refactors**
  - Sidebar: switch avatar and credit indicators to orange.
  - Create Project modals: dark theme and orange buttons across project-header, workspace-layout, and pc-workspace-layout.
  - Code editor streaming UI: replace blue accents with orange (buttons, badges, line highlights, cursor).

<sup>Written for commit ca3cfd938e059990526a61924c53f7172ac2ff16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

