### PR TITLE
Claude/revert to commit uz9p7

### DIFF
--- a/components/workspace/code-preview-panel.tsx
+++ b/components/workspace/code-preview-panel.tsx
@@ -2925,9 +2925,12 @@ export default function TodoApp() {
             }}
           >
             <WebPreviewNavigation className="fixed top-0 left-0 right-0 z-50 bg-gray-900/95 backdrop-blur-sm border-b border-gray-800/60">
+              {/* Spacer to push all controls right */}
+              {!isMobile && <div className="flex-1" />}
+
               {/* Tab switching buttons + Chat Session Selector - hidden on mobile */}
               {!isMobile && (
-                <div className="flex items-center gap-0.5 ml-2">
+                <div className="flex items-center gap-0.5">
                   <WebPreviewNavigationButton
                     onClick={() => onTabChange("code")}
                     tooltip="Switch to Code View"
@@ -2960,18 +2963,15 @@ export default function TodoApp() {
                 </div>
               )}
 
-              {/* Spacer to push controls right */}
-              {!isMobile && <div className="flex-1" />}
-
               {/* For Expo: No Visual Editor/Responsive. For others: show icons only */}
               {!isExpoProject && (
                 <>
-                  {/* Device selector - hidden on mobile */}
-                  {!isMobile && <WebPreviewDeviceSelector />}
                   <VisualEditorToggle
                     isEnabled={isVisualEditorEnabled}
                     onToggle={setIsVisualEditorEnabled}
                   />
+                  {/* Device selector - hidden on mobile */}
+                  {!isMobile && <WebPreviewDeviceSelector />}
                 </>
               )}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Right-align the web preview toolbar on desktop by moving the flex spacer to the start and removing extra spacing. Tabs/chat, Visual Edit, device selector, URL bar, and play/stop now sit together without gaps; mobile is unchanged.

<sup>Written for commit c3ce31a5a4e5062d249fb6453b83056616f5fff3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

