### PR TITLE
Fix workspace title and auto-preview using stale files after stream

### DIFF
--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -444,12 +444,14 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
       }
 
       if (shouldCreatePreview) {
-        // Trigger preview creation with a small delay to ensure tab switch is complete
+        // Trigger preview creation with a longer delay to ensure all file writes
+        // to IndexedDB are fully committed before we read them for preview.
+        // Users reported that auto-started previews had stale/old file states.
         setTimeout(() => {
           if (codePreviewRef.current) {
             codePreviewRef.current.createPreview()
           }
-        }, 100)
+        }, 1500)
       }
     }
 
@@ -653,6 +655,19 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
       }
     }
   }, [searchParams, clientProjects, selectedProject, router, isLoadingProjects])
+
+  // Update browser tab title based on selected project
+  useEffect(() => {
+    if (selectedProject?.name) {
+      document.title = `${selectedProject.name} - PiPilot Workspace`
+    } else {
+      document.title = 'PiPilot Workspace'
+    }
+    // Restore original title on unmount
+    return () => {
+      document.title = "PiPilot - Canada's First Agentic Vibe Coding Platform | AI App Builder"
+    }
+  }, [selectedProject?.name])
 
   // Also reload when newProjectId changes (in case project was just created)
   useEffect(() => {


### PR DESCRIPTION
1. Add dynamic browser tab title that shows project name when a project is selected (e.g. "MyApp - PiPilot Workspace") instead of the global PiPilot title.

2. Fix auto-start preview after AI stream using stale/old file states:
   - Increase delay from 100ms to 1500ms before creating preview after stream completion, giving IndexedDB writes time to flush.
   - Increase auto-refresh delay from 500ms to 1500ms for same reason.
   - Add 200ms yield before reading files in both createPreview() and refreshPreviewWithLatestFiles() to ensure pending IndexedDB transactions complete before fetching project files.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the selected project in the browser tab and prevent auto-started previews from using stale files after streaming by waiting for IndexedDB writes to finish.

- **New Features**
  - Browser tab shows "<Project> - PiPilot Workspace"; falls back to "PiPilot Workspace" and restores the original title on unmount.

- **Bug Fixes**
  - Delay preview creation after stream from 100ms to 1500ms.
  - Delay auto-refresh after stream from 500ms to 1500ms.
  - Re-init storage manager and wait 200ms before reading files in createPreview() and refreshPreviewWithLatestFiles() to ensure IndexedDB writes are flushed.

<sup>Written for commit 55e4765640f8675042557cd912dfe346d1c9deb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

