### PR TITLE
Fix mobile preview stuck on streaming view after AI finishes

### DIFF
--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -436,6 +436,12 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
     const handleAiStreamComplete = (event: CustomEvent) => {
       const { shouldSwitchToPreview, shouldCreatePreview } = event.detail
 
+      // Stream is complete — clear streaming state immediately so the preview panel
+      // doesn't keep showing <AIRespondingView/>. Without this, on mobile there's a
+      // timing gap: mobileTab switches to 'preview' here, but isAIStreaming only
+      // becomes false later (after setIsLoading(false) → useEffect → ai-streaming-state).
+      setIsAIStreaming(false)
+
       if (shouldSwitchToPreview) {
         setActiveTab('preview')
         if (isMobile) {


### PR DESCRIPTION
On mobile, when AI streaming completes, the tab switches to 'preview' but isAIStreaming remains true for 1-2 render cycles due to a timing gap (ai-stream-complete fires before setIsLoading(false) -> useEffect -> ai-streaming-state). This caused <AIRespondingView/> to persist instead of showing the actual preview. Desktop was unaffected because pc-workspace-layout doesn't pass isAIStreaming to CodePreviewPanel.

Fix: clear isAIStreaming immediately in the handleAiStreamComplete handler so both state updates are batched in the same render.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a mobile issue where the preview stayed on the loading view after streaming ended. The completion handler now clears the streaming flag immediately so the preview shows right away in the same render cycle.

<sup>Written for commit 21478e6878874fbd6e9c470491c10f4ee4b027eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

