### PR TITLE
Add Queue component for message queue and AI todo management

### DIFF
--- a/components/ai-elements/queue.tsx
+++ b/components/ai-elements/queue.tsx
@@ -28,7 +28,7 @@ export type QueueTodo = {
   id: string;
   title: string;
   description?: string;
-  status?: "pending" | "completed";
+  status?: "pending" | "completed" | "in_progress";
 };
 
 export type QueueItemProps = ComponentProps<"li">;
@@ -36,7 +36,7 @@ export type QueueItemProps = ComponentProps<"li">;
 export const QueueItem = ({ className, ...props }: QueueItemProps) => (
   <li
     className={cn(
-      "group flex flex-col gap-1 rounded-md px-3 py-1 text-sm transition-colors hover:bg-muted",
+      "group flex flex-col gap-1 rounded-md px-3 py-1.5 text-sm transition-colors hover:bg-gray-800/60",
       className
     )}
     {...props}
@@ -45,19 +45,23 @@ export const QueueItem = ({ className, ...props }: QueueItemProps) => (
 
 export type QueueItemIndicatorProps = ComponentProps<"span"> & {
   completed?: boolean;
+  inProgress?: boolean;
 };
 
 export const QueueItemIndicator = ({
   completed = false,
+  inProgress = false,
   className,
   ...props
 }: QueueItemIndicatorProps) => (
   <span
     className={cn(
-      "mt-0.5 inline-block size-2.5 rounded-full border",
+      "mt-0.5 inline-block size-2.5 shrink-0 rounded-full border",
       completed
-        ? "border-muted-foreground/20 bg-muted-foreground/10"
-        : "border-muted-foreground/50",
+        ? "border-green-500/40 bg-green-500/30"
+        : inProgress
+        ? "border-orange-500/60 bg-orange-500/40 animate-pulse"
+        : "border-gray-500/50 bg-transparent",
       className
     )}
     {...props}
@@ -77,8 +81,8 @@ export const QueueItemContent = ({
     className={cn(
       "line-clamp-1 grow break-words",
       completed
-        ? "text-muted-foreground/50 line-through"
-        : "text-muted-foreground",
+        ? "text-gray-500 line-through"
+        : "text-gray-300",
       className
     )}
     {...props}
@@ -96,10 +100,10 @@ export const QueueItemDescription = ({
 }: QueueItemDescriptionProps) => (
   <div
     className={cn(
-      "ml-6 text-xs",
+      "ml-[1.125rem] text-xs",
       completed
-        ? "text-muted-foreground/40 line-through"
-        : "text-muted-foreground",
+        ? "text-gray-600 line-through"
+        : "text-gray-500",
       className
     )}
     {...props}
@@ -112,7 +116,7 @@ export const QueueItemActions = ({
   className,
   ...props
 }: QueueItemActionsProps) => (
-  <div className={cn("flex gap-1", className)} {...props} />
+  <div className={cn("flex gap-1 shrink-0", className)} {...props} />
 );
 
 export type QueueItemActionProps = Omit<
@@ -126,7 +130,7 @@ export const QueueItemAction = ({
 }: QueueItemActionProps) => (
   <Button
     className={cn(
-      "size-auto rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted-foreground/10 hover:text-foreground group-hover:opacity-100",
+      "size-auto rounded p-1 text-gray-500 opacity-0 transition-opacity hover:bg-gray-700/50 hover:text-orange-400 group-hover:opacity-100",
       className
     )}
     size="icon"
@@ -142,7 +146,7 @@ export const QueueItemAttachment = ({
   className,
   ...props
 }: QueueItemAttachmentProps) => (
-  <div className={cn("mt-1 flex flex-wrap gap-2", className)} {...props} />
+  <div className={cn("mt-1 flex flex-wrap gap-2 ml-[1.125rem]", className)} {...props} />
 );
 
 export type QueueItemImageProps = ComponentProps<"img">;
@@ -153,7 +157,7 @@ export const QueueItemImage = ({
 }: QueueItemImageProps) => (
   <img
     alt=""
-    className={cn("h-8 w-8 rounded border object-cover", className)}
+    className={cn("h-8 w-8 rounded border border-gray-700 object-cover", className)}
     height={32}
     width={32}
     {...props}
@@ -169,7 +173,7 @@ export const QueueItemFile = ({
 }: QueueItemFileProps) => (
   <span
     className={cn(
-      "flex items-center gap-1 rounded border bg-muted px-2 py-1 text-xs",
+      "flex items-center gap-1 rounded border border-gray-700 bg-gray-800 px-2 py-1 text-xs text-gray-300",
       className
     )}
     {...props}
@@ -186,7 +190,7 @@ export const QueueList = ({
   className,
   ...props
 }: QueueListProps) => (
-  <ScrollArea className={cn("-mb-1 mt-2", className)} {...props}>
+  <ScrollArea className={cn("-mb-1 mt-1.5", className)} {...props}>
     <div className="max-h-40 pr-4">
       <ul>{children}</ul>
     </div>
@@ -215,7 +219,7 @@ export const QueueSectionTrigger = ({
   <CollapsibleTrigger asChild>
     <button
       className={cn(
-        "group flex w-full items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors hover:bg-muted",
+        "group/trigger flex w-full items-center justify-between rounded-lg bg-gray-800/40 px-3 py-1.5 text-left font-medium text-gray-400 text-xs transition-colors hover:bg-gray-800/70",
         className
       )}
       type="button"
@@ -241,10 +245,11 @@ export const QueueSectionLabel = ({
   ...props
 }: QueueSectionLabelProps) => (
   <span className={cn("flex items-center gap-2", className)} {...props}>
-    <ChevronDownIcon className="group-data-[state=closed]:-rotate-90 size-4 transition-transform" />
+    <ChevronDownIcon className="group-data-[state=closed]/trigger:-rotate-90 size-3.5 transition-transform text-gray-500" />
     {icon}
-    <span>
-      {count} {label}
+    <span className="text-gray-400">
+      {count !== undefined && <span className="text-orange-400 font-semibold mr-1">{count}</span>}
+      {label}
     </span>
   </span>
 );
@@ -266,7 +271,7 @@ export type QueueProps = ComponentProps<"div">;
 export const Queue = ({ className, ...props }: QueueProps) => (
   <div
     className={cn(
-      "flex flex-col gap-2 rounded-xl border border-border bg-background px-3 pt-2 pb-2 shadow-xs",
+      "flex flex-col gap-1.5 rounded-xl border border-gray-700/60 bg-gray-900/90 px-2 pt-2 pb-2 shadow-lg",
       className
     )}
     {...props}

--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -31,6 +31,22 @@ import {
 import { ModelSelector } from '@/components/ui/model-selector'
 import { cn, filterUnwantedFiles } from '@/lib/utils'
 import { Actions, Action } from '@/components/ai-elements/actions'
+import {
+  Queue,
+  QueueItem,
+  QueueItemAction,
+  QueueItemActions,
+  QueueItemContent,
+  QueueItemDescription,
+  QueueItemIndicator,
+  QueueList,
+  QueueSection,
+  QueueSectionContent,
+  QueueSectionLabel,
+  QueueSectionTrigger,
+  type QueueTodo,
+} from '@/components/ai-elements/queue'
+import { ListTodo } from 'lucide-react'
 import { FileAttachmentDropdown } from "@/components/ui/file-attachment-dropdown"
 import { FileAttachmentBadge } from "@/components/ui/file-attachment-badge"
 import { FileSearchResult, FileLookupService } from "@/lib/file-lookup-service"
@@ -1395,6 +1411,9 @@ export function ChatPanelV2({
   promptQueueRef.current = promptQueue
   const isProcessingQueueRef = useRef(false)
 
+  // AI-managed todos - populated via manage_todos tool calls from the AI agent
+  const [aiTodos, setAiTodos] = useState<QueueTodo[]>([])
+
   // Persist prompt queue to localStorage
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -1469,6 +1488,30 @@ export function ChatPanelV2({
 
   const clearQueue = useCallback(() => {
     setPromptQueue([])
+  }, [])
+
+  // Extract AI todos from manage_todos tool calls (uses latest tool call data)
+  const extractAiTodosFromToolCalls = useCallback((toolCalls: Array<{ toolName: string; input?: any; status: string }> | undefined) => {
+    if (!toolCalls || toolCalls.length === 0) return
+    // Find the most recent manage_todos call
+    const todoCalls = toolCalls.filter(tc => tc.toolName === 'manage_todos' && tc.input?.todos)
+    if (todoCalls.length === 0) return
+    const latestCall = todoCalls[todoCalls.length - 1]
+    const todos: QueueTodo[] = latestCall.input.todos.map((t: any) => ({
+      id: t.id || `todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      title: t.title,
+      description: t.description || undefined,
+      status: t.status || 'pending',
+    }))
+    setAiTodos(todos)
+  }, [])
+
+  const removeAiTodo = useCallback((id: string) => {
+    setAiTodos(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const clearAiTodos = useCallback(() => {
+    setAiTodos([])
   }, [])
 
   // Supabase token management - automatic refresh
@@ -2565,6 +2608,17 @@ export function ChatPanelV2({
                 return newMap
               })
 
+              // Handle manage_todos tool in continuation
+              if (toolCall.toolName === 'manage_todos' && toolCall.args?.todos) {
+                const todos: QueueTodo[] = toolCall.args.todos.map((t: any) => ({
+                  id: t.id || `todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                  title: t.title,
+                  description: t.description || undefined,
+                  status: t.status || 'pending',
+                }))
+                setAiTodos(todos)
+              }
+
               const clientSideTools = [
                 'write_file',
                 'edit_file',
@@ -3096,9 +3150,27 @@ export function ChatPanelV2({
         })
 
         setActiveToolCalls(toolCallsMap)
+
+        // Restore AI todos from the most recent manage_todos tool call in history
+        const allToolCalls = Array.from(toolCallsMap.values()).flat()
+        const todoCalls = allToolCalls.filter(tc => tc.toolName === 'manage_todos' && tc.input?.todos)
+        if (todoCalls.length > 0) {
+          const latestTodoCall = todoCalls[todoCalls.length - 1]
+          const restoredTodos: QueueTodo[] = latestTodoCall.input.todos.map((t: any) => ({
+            id: t.id || `todo-${Math.random().toString(36).slice(2, 7)}`,
+            title: t.title,
+            description: t.description || undefined,
+            status: t.status || 'pending',
+          }))
+          // Only restore if there are non-completed todos
+          if (restoredTodos.some((t: QueueTodo) => t.status !== 'completed')) {
+            setAiTodos(restoredTodos)
+          }
+        }
       } else {
         setMessages([])
         setActiveToolCalls(new Map())
+        setAiTodos([])
       }
     } catch (error) {
       console.error(`[ChatPanelV2] Error loading messages for project ${project?.id}:`, error)
@@ -3335,9 +3407,20 @@ export function ChatPanelV2({
 
               console.log('[ChatPanelV2][ClientTool][Continuation] 🔧 Continuation tool call:', toolCall.toolName)
 
+              // Handle manage_todos tool in continuation
+              if (toolCall.toolName === 'manage_todos' && toolCall.args?.todos) {
+                const todos: QueueTodo[] = toolCall.args.todos.map((t: any) => ({
+                  id: t.id || `todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                  title: t.title,
+                  description: t.description || undefined,
+                  status: t.status || 'pending',
+                }))
+                setAiTodos(todos)
+              }
+
               const clientSideTools = [
-                'write_file', 
-                'edit_file', 
+                'write_file',
+                'edit_file',
                 'client_replace_string_in_file',
                 'delete_file',
                 'delete_folder',
@@ -3349,7 +3432,7 @@ export function ChatPanelV2({
                 'create_database',
                 'request_supabase_connection'
               ]
-              
+
               if (clientSideTools.includes(toolCall.toolName)) {
                 const { handleClientFileOperation } = await import('@/lib/client-file-tools')
 
@@ -3793,6 +3876,17 @@ export function ChatPanelV2({
                   newMap.set(stream.id, [...continuationToolCalls])
                   return newMap
                 })
+
+                // Handle manage_todos tool in continuation
+                if (parsed.toolName === 'manage_todos' && parsed.input?.todos) {
+                  const todos: QueueTodo[] = parsed.input.todos.map((t: any) => ({
+                    id: t.id || `todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                    title: t.title,
+                    description: t.description || undefined,
+                    status: t.status || 'pending',
+                  }))
+                  setAiTodos(todos)
+                }
 
                 // Execute client-side tools
                 const clientSideTools = [
@@ -4907,6 +5001,17 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                 return newMap
               })
 
+              // Handle manage_todos tool - extract and display todos in the Queue UI
+              if (toolCall.toolName === 'manage_todos' && toolCall.args?.todos) {
+                const todos: QueueTodo[] = toolCall.args.todos.map((t: any) => ({
+                  id: t.id || `todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                  title: t.title,
+                  description: t.description || undefined,
+                  status: t.status || 'pending',
+                }))
+                setAiTodos(todos)
+              }
+
               // Check if this is a client-side tool (both read and write operations)
               const clientSideTools = [
                 'write_file',
@@ -5711,7 +5816,8 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                     const inlineToolCalls = toolCalls.filter(tc =>
                       tc.toolName !== 'request_supabase_connection' &&
                       tc.toolName !== 'continue_backend_implementation' &&
-                      tc.toolName !== 'suggest_next_steps'
+                      tc.toolName !== 'suggest_next_steps' &&
+                      tc.toolName !== 'manage_todos'
                     )
                     return (
                       <MessageWithTools
@@ -5731,7 +5837,8 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                     const regularToolCalls = toolCalls?.filter(tc =>
                       tc.toolName !== 'request_supabase_connection' &&
                       tc.toolName !== 'continue_backend_implementation' &&
-                      tc.toolName !== 'suggest_next_steps'
+                      tc.toolName !== 'suggest_next_steps' &&
+                      tc.toolName !== 'manage_todos'
                     )
                     return regularToolCalls && regularToolCalls.length > 0 ? (
                       <ToolActivityPanel
@@ -5810,46 +5917,122 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
         : ''
         }`} style={{ backgroundColor: 'rgba(17, 24, 39, 0.8)' }}>
 
-        {/* Prompt Queue - Collapsible accordion with Claude-style badges */}
-        {promptQueue.length > 0 && (
-          <div className="mb-2">
-            <button
-              className="flex items-center gap-2 text-xs text-gray-400 hover:text-gray-300 transition-colors mb-1"
-              onClick={() => {
-                const el = document.getElementById('queue-accordion')
-                if (el) el.classList.toggle('hidden')
-              }}
-            >
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-800 text-gray-300 text-[11px] font-medium">
-                {promptQueue.length} queued
-              </span>
-              {promptQueue.length > 1 && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); clearQueue() }}
-                  className="text-[11px] text-gray-500 hover:text-red-400 transition-colors"
-                >
-                  Clear all
-                </button>
-              )}
-            </button>
-            <div id="queue-accordion" className="flex flex-col gap-1">
-              {promptQueue.map((item, index) => (
-                <div
-                  key={item.id}
-                  className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-gray-800/60 text-xs group"
-                >
-                  <span className="text-gray-500 font-mono text-[10px] flex-shrink-0">#{index + 1}</span>
-                  <span className="truncate text-gray-300 flex-1">{item.text}</span>
-                  <button
-                    onClick={() => removeFromQueue(item.id)}
-                    className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all flex-shrink-0"
-                  >
-                    <X className="size-3" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
+        {/* Queue Panel - Prompt Queue + AI Todos using Queue component */}
+        {(promptQueue.length > 0 || aiTodos.length > 0) && (
+          <Queue className="mb-2">
+            {/* Queued Messages Section */}
+            {promptQueue.length > 0 && (
+              <QueueSection>
+                <QueueSectionTrigger>
+                  <QueueSectionLabel count={promptQueue.length} label="Queued" />
+                  {promptQueue.length > 1 && (
+                    <button
+                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); clearQueue() }}
+                      className="text-[11px] text-gray-500 hover:text-red-400 transition-colors"
+                    >
+                      Clear all
+                    </button>
+                  )}
+                </QueueSectionTrigger>
+                <QueueSectionContent>
+                  <QueueList>
+                    {promptQueue.map((item) => (
+                      <QueueItem key={item.id}>
+                        <div className="flex items-center gap-2">
+                          <QueueItemIndicator />
+                          <QueueItemContent>{item.text}</QueueItemContent>
+                          <QueueItemActions>
+                            <QueueItemAction
+                              aria-label="Send now"
+                              title="Send now"
+                              onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                // Move this item to front of queue so it processes next
+                                setPromptQueue(prev => {
+                                  const item_ = prev.find(p => p.id === item.id)
+                                  if (!item_) return prev
+                                  return [item_, ...prev.filter(p => p.id !== item.id)]
+                                })
+                              }}
+                            >
+                              <ArrowUp size={12} />
+                            </QueueItemAction>
+                            <QueueItemAction
+                              aria-label="Remove from queue"
+                              title="Remove from queue"
+                              onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                removeFromQueue(item.id)
+                              }}
+                            >
+                              <Trash2 size={12} />
+                            </QueueItemAction>
+                          </QueueItemActions>
+                        </div>
+                      </QueueItem>
+                    ))}
+                  </QueueList>
+                </QueueSectionContent>
+              </QueueSection>
+            )}
+
+            {/* AI-Managed Todos Section */}
+            {aiTodos.length > 0 && (
+              <QueueSection>
+                <QueueSectionTrigger>
+                  <QueueSectionLabel
+                    count={aiTodos.filter(t => t.status !== 'completed').length}
+                    label="Todo"
+                    icon={<ListTodo size={13} className="text-orange-400" />}
+                  />
+                  {aiTodos.every(t => t.status === 'completed') && (
+                    <button
+                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); clearAiTodos() }}
+                      className="text-[11px] text-gray-500 hover:text-red-400 transition-colors"
+                    >
+                      Clear
+                    </button>
+                  )}
+                </QueueSectionTrigger>
+                <QueueSectionContent>
+                  <QueueList>
+                    {aiTodos.map((todo) => (
+                      <QueueItem key={todo.id}>
+                        <div className="flex items-center gap-2">
+                          <QueueItemIndicator
+                            completed={todo.status === 'completed'}
+                            inProgress={todo.status === 'in_progress'}
+                          />
+                          <QueueItemContent completed={todo.status === 'completed'}>
+                            {todo.title}
+                          </QueueItemContent>
+                          <QueueItemActions>
+                            <QueueItemAction
+                              aria-label="Remove todo"
+                              onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                removeAiTodo(todo.id)
+                              }}
+                            >
+                              <X size={12} />
+                            </QueueItemAction>
+                          </QueueItemActions>
+                        </div>
+                        {todo.description && (
+                          <QueueItemDescription completed={todo.status === 'completed'}>
+                            {todo.description}
+                          </QueueItemDescription>
+                        )}
+                      </QueueItem>
+                    ))}
+                  </QueueList>
+                </QueueSectionContent>
+              </QueueSection>
+            )}
+          </Queue>
         )}
 
         {/* Main Input Container - Claude-style rounded card */}


### PR DESCRIPTION
- Replace inline queue accordion UI with composable Queue component from ai-elements/queue.tsx (collapsible sections, action buttons)
- Add manage_todos server tool that AI agent can call to create and track task progress displayed in real-time above the chat input
- Style Queue component with PiPilot dark theme and orange accents
- Support queue message actions (send now, remove) and todo states (pending, in_progress with pulse animation, completed with strikethrough)
- Restore AI todos from message history on page reload
- Filter manage_todos from inline tool rendering like suggest_next_steps

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composable Queue panel above the chat input to show queued messages and a task list, plus a new manage_todos server tool that builds and updates that list with live status.

- New Features
  - Replaced the inline queue accordion with a reusable Queue component (collapsible sections, dark theme, orange accents).
  - Added manage_todos tool for multi-step tasks; sends the full list, enforces a single in_progress item, and supports pending/in_progress/completed.
  - Shows the task list in the Queue panel and restores it from message history on reload.
  - Queue actions: send a message now or remove it from the queue.
  - Filtered manage_todos out of inline tool rendering and added it to read-only/UI-initial tool sets.
  - Updated system guidance to use manage_todos for complex work and keep titles short.

<sup>Written for commit 94071347f14b9db1164299a1924b4b71168d034e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

