### PR TITLE
Fix Build button auto-send by using sendButtonRef.click() instead of …

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5861,9 +5861,11 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                                   const planSteps = (input.steps || []).map((s: any, i: number) => `${i + 1}. ${s.title}: ${s.description}`).join('\n')
                                   const buildPrompt = `Build the following plan now:\n\n**${input.title}**\n${input.description}\n\nSteps:\n${planSteps}\n\nTech Stack: ${(input.techStack || []).join(', ')}\n\nBuild this complete application following the plan above. Start implementing immediately.`
                                   setInput(buildPrompt)
+                                  // Use sendButtonRef.click() like initial prompt to avoid stale closure issue
                                   setTimeout(() => {
-                                    const syntheticEvent = { preventDefault: () => {} } as React.FormEvent
-                                    handleEnhancedSubmit(syntheticEvent)
+                                    if (sendButtonRef.current) {
+                                      sendButtonRef.current.click()
+                                    }
                                   }, 150)
                                 }}
                                 onRefine={() => {


### PR DESCRIPTION
…stale closure

The onBuild handler was calling handleEnhancedSubmit directly from a setTimeout, but the closure captured the old (empty) input state before setInput took effect. Now uses sendButtonRef.current.click() like the initial prompt handler, which invokes handleEnhancedSubmit from the latest render cycle with the correct input.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Build button auto-send by triggering sendButtonRef.current.click() instead of calling handleEnhancedSubmit inside a setTimeout. This avoids the stale closure and ensures the newly set build prompt is submitted from the latest render.

<sup>Written for commit 240e8d3ec1d10385474c79c6bebecbb6e41af635. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

