### PR TITLE
Fix suggestion click to auto-send using sendButtonRef like build plan

### DIFF
--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -5919,10 +5919,12 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                         isVisible={!isMessageStreaming}
                         onSuggestionClick={(prompt) => {
                           setInput(prompt)
+                          // Use sendButtonRef.click() like build plan to avoid stale closure issue
                           setTimeout(() => {
-                            const syntheticEvent = { preventDefault: () => {} } as React.FormEvent
-                            handleEnhancedSubmit(syntheticEvent)
-                          }, 100)
+                            if (sendButtonRef.current) {
+                              sendButtonRef.current.click()
+                            }
+                          }, 150)
                         }}
                       />
                     ) : null


### PR DESCRIPTION
The suggestion click handler was using handleEnhancedSubmit directly which suffers from stale closure issues. Changed to use sendButtonRef.current.click() with 150ms delay, matching the pattern used by build plan's onBuild/onRefine.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes auto-send when clicking a suggestion by triggering the send button via ref with a 150ms delay. Prevents stale closure bugs and matches build plan behavior.

- **Bug Fixes**
  - Replaced direct handleEnhancedSubmit call with sendButtonRef.current.click() (150ms delay) in onSuggestionClick.
  - Aligns with build plan’s onBuild/onRefine pattern to ensure reliable auto-send.

<sup>Written for commit 17ff5222dd488683b8d6edf9b2830997988c7dfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

