### PR TITLE
Add Playwright Chromium E2B template and GitHub workflow

### DIFF
--- a/.github/workflows/deploy-playwright-template.yml
+++ b/.github/workflows/deploy-playwright-template.yml
@@ -1,0 +1,71 @@
+name: Deploy Playwright Chromium E2B Template
+
+on:
+  workflow_dispatch:
+    inputs:
+      e2b_access_token:
+        description: 'E2B Access Token (from https://e2b.dev/dashboard?tab=personal)'
+        required: true
+        type: string
+      template_name:
+        description: 'Template Name'
+        required: true
+        type: string
+        default: 'playwright-chromium'
+      cpu_count:
+        description: 'CPU Cores (default: 2, Pro plan required for >2)'
+        required: false
+        type: string
+        default: '2'
+      memory_mb:
+        description: 'Memory in MB (default: 4096, Pro plan required for >4096)'
+        required: false
+        type: string
+        default: '4096'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install pnpm
+      run: npm install -g pnpm
+
+    - name: Install E2B CLI
+      run: pnpm add @e2b/cli
+
+    - name: Set E2B Access Token
+      run: echo "E2B_ACCESS_TOKEN=${{ inputs.e2b_access_token }}" >> $GITHUB_ENV
+
+    - name: Build and deploy Playwright Chromium E2B template
+      run: |
+        npx e2b template build \
+          --name ${{ inputs.template_name }} \
+          --dockerfile e2b-playwright.Dockerfile \
+          --cpu-count ${{ inputs.cpu_count }} \
+          --memory-mb ${{ inputs.memory_mb }}
+      env:
+        E2B_ACCESS_TOKEN: ${{ inputs.e2b_access_token }}
+
+    - name: Display template info
+      run: |
+        echo "Template deployed successfully!"
+        echo "Template name: ${{ inputs.template_name }}"
+        echo "CPU cores: ${{ inputs.cpu_count }}"
+        echo "Memory: ${{ inputs.memory_mb }}MB"
+        echo ""
+        echo "Features included:"
+        echo "  - Playwright with Chromium browser"
+        echo "  - Node.js 20 runtime"
+        echo "  - Pre-initialized /app project directory"
+        echo ""
+        echo "Usage in code:"
+        echo '  const sandbox = await Sandbox.create("${{ inputs.template_name }}")'

--- a/e2b-playwright.Dockerfile
+++ b/e2b-playwright.Dockerfile
@@ -1,0 +1,88 @@
+# PiPilot Playwright Chromium E2B Template
+# Lightweight template for browser automation with Playwright and Chromium
+# Alias: playwright-chromium
+
+FROM node:20-slim
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Pre-configure keyboard settings to avoid prompts
+RUN echo 'keyboard-configuration keyboard-configuration/layout select English (US)' | debconf-set-selections
+RUN echo 'keyboard-configuration keyboard-configuration/layoutcode select us' | debconf-set-selections
+
+# Install system dependencies required for Playwright/Chromium
+RUN apt-get update && apt-get install -y \
+    wget \
+    curl \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libatspi2.0-0 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libexpat1 \
+    libgbm1 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxrender1 \
+    libxshmfence1 \
+    libxss1 \
+    libxtst6 \
+    xdg-utils \
+    libu2f-udev \
+    libvulkan1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up working directory for the app
+WORKDIR /app
+
+# Initialize a new Node.js project
+RUN npm init -y
+
+# Install Playwright Node.js package
+RUN npm install playwright
+
+# Install Playwright browsers and system dependencies
+# PLAYWRIGHT_BROWSERS_PATH=0 installs browsers in node_modules (accessible by all users)
+RUN PLAYWRIGHT_BROWSERS_PATH=0 npx playwright install --with-deps chromium
+
+# Allow all users to write output files in /app
+RUN chmod a+rwX /app
+
+# Create a user with proper setup (matching E2B conventions)
+RUN useradd -m -s /bin/bash user
+
+# Give full permissions to the user on their home directory
+RUN chmod -R a+rwX /home/user && chown -R user:user /home/user
+
+# Switch to non-root user for runtime
+USER user
+WORKDIR /home/user
+
+# Set environment variables
+ENV NODE_ENV=development
+ENV PLAYWRIGHT_BROWSERS_PATH=0
+
+# Default command
+CMD ["/bin/bash"]


### PR DESCRIPTION
New lightweight E2B template focused on Playwright with Chromium for browser automation. Includes Dockerfile and manual-dispatch workflow for deployment.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lightweight E2B template for Playwright with Chromium and a manual GitHub Action to build and deploy it. Speeds up starting browser automation by shipping Node.js 20 with Playwright and all system deps preinstalled.

- **New Features**
  - Dockerfile: Node 20-slim, Playwright + Chromium installed with required libs, non-root user, writable /app.
  - GitHub Action: Manual deploy via E2B CLI with inputs for access token, template name (default: playwright-chromium), CPU, and memory.

- **Migration**
  - Manually run “Deploy Playwright Chromium E2B Template” and provide an E2B access token.
  - Use the deployed template name in code, e.g., Sandbox.create("<template_name>").

<sup>Written for commit 9338143570ebde3a15bd9937225b56e0bcbb40b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

