### PR TITLE
Fix hover-dependent UI elements for mobile devices

### DIFF
--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -292,7 +292,7 @@ export function PromptInputAttachment({
           {...props}
         >
           <div className="relative size-5 shrink-0">
-            <div className="absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded bg-background transition-opacity group-hover:opacity-0">
+            <div className="absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded bg-background transition-opacity md:group-hover:opacity-0">
               {isImage ? (
                 <img
                   alt={filename || "attachment"}
@@ -309,7 +309,7 @@ export function PromptInputAttachment({
             </div>
             <Button
               aria-label="Remove attachment"
-              className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 [&>svg]:size-2.5"
+              className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto md:group-hover:opacity-100 max-md:opacity-100 [&>svg]:size-2.5"
               onClick={(e) => {
                 e.stopPropagation();
                 attachments.remove(data.id);

--- a/components/ai-elements/queue.tsx
+++ b/components/ai-elements/queue.tsx
@@ -130,7 +130,7 @@ export const QueueItemAction = ({
 }: QueueItemActionProps) => (
   <Button
     className={cn(
-      "size-auto rounded p-1 text-gray-500 opacity-0 transition-opacity hover:bg-gray-700/50 hover:text-orange-400 group-hover:opacity-100",
+      "size-auto rounded p-1 text-gray-500 md:opacity-0 transition-opacity hover:bg-gray-700/50 hover:text-orange-400 md:group-hover:opacity-100",
       className
     )}
     size="icon"

--- a/components/database/storage-manager.tsx
+++ b/components/database/storage-manager.tsx
@@ -407,7 +407,7 @@ export default function StorageManager({ databaseId }: StorageManagerProps) {
                       }}
                     />
                     {isPreviewable(file.mime_type) && (
-                      <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-center justify-center opacity-0 group-hover:opacity-100">
+                      <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-center justify-center md:opacity-0 md:group-hover:opacity-100">
                         <Eye className="h-8 w-8 text-white" />
                       </div>
                     )}
@@ -418,7 +418,7 @@ export default function StorageManager({ databaseId }: StorageManagerProps) {
                       <FileText className="h-12 w-12" />
                       <span className="text-xs">PDF Document</span>
                     </div>
-                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-center justify-center opacity-0 group-hover:opacity-100">
+                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-center justify-center md:opacity-0 md:group-hover:opacity-100">
                       <Eye className="h-8 w-8 text-white" />
                     </div>
                   </>

--- a/components/project-grid-pc.tsx
+++ b/components/project-grid-pc.tsx
@@ -245,7 +245,7 @@ export function ProjectGridPC() {
                       {project.category}
                     </Badge>
                   </div>
-                  <div className="absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                  <div className="absolute bottom-3 right-3 md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-300">
                     <ExternalLink className="w-5 h-5 text-white" />
                   </div>
                 </div>
@@ -264,7 +264,7 @@ export function ProjectGridPC() {
             </Link>
             <button
               onClick={(e) => handleDeleteProject(project.id, e)}
-              className="absolute top-2 left-2 p-1.5 bg-red-500 hover:bg-red-600 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10"
+              className="absolute top-2 left-2 p-1.5 bg-red-500 hover:bg-red-600 text-white rounded-full md:opacity-0 md:group-hover:opacity-100 transition-opacity duration-200 z-10"
               title="Delete project"
             >
               <Trash2 className="w-4 h-4 fill-current" />

--- a/components/project-grid.tsx
+++ b/components/project-grid.tsx
@@ -686,7 +686,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
                       {project.category}
                     </Badge>
                   </div>
-                  <div className="absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-2 group-hover:translate-y-0">
+                  <div className="absolute bottom-3 right-3 md:opacity-0 md:group-hover:opacity-100 transition-all duration-300 transform md:translate-y-2 md:group-hover:translate-y-0">
                     <div className="p-2 bg-orange-600 rounded-full shadow-lg">
                       <ExternalLink className="w-4 h-4 text-white" />
                     </div>
@@ -706,7 +706,7 @@ export function ProjectGrid({ filterBy = 'all', sortBy = 'activity', sortOrder =
                       </svg>
                       {timeAgo(project.createdAt)}
                     </div>
-                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                       <span className="text-xs text-orange-400 font-medium">Open →</span>
                     </div>
                   </div>

--- a/components/schema-visualizer.tsx
+++ b/components/schema-visualizer.tsx
@@ -240,7 +240,7 @@ export function SchemaVisualizer() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="opacity-0 group-hover:opacity-100 h-6 w-6 p-0"
+                      className="md:opacity-0 md:group-hover:opacity-100 h-6 w-6 p-0"
                       onClick={(e) => {
                         e.stopPropagation()
                         toggleTableVisibility(table.name)

--- a/components/ui/chat-session-selector.tsx
+++ b/components/ui/chat-session-selector.tsx
@@ -323,7 +323,7 @@ export function ChatSessionSelector({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 hover:opacity-100"
+                          className="h-6 w-6 p-0 md:opacity-0 md:group-hover:opacity-100 hover:opacity-100"
                           onClick={(e) => startEditing(session, e)}
                         >
                           <Pencil className="h-3 w-3" />
@@ -331,7 +331,7 @@ export function ChatSessionSelector({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 hover:opacity-100 hover:text-destructive"
+                          className="h-6 w-6 p-0 md:opacity-0 md:group-hover:opacity-100 hover:opacity-100 hover:text-destructive"
                           onClick={(e) => handleDeleteSession(session.id, e)}
                         >
                           <Trash2 className="h-3 w-3" />

--- a/components/ui/conversation-branch.tsx
+++ b/components/ui/conversation-branch.tsx
@@ -267,7 +267,7 @@ function BranchItem({
       </div>
 
       {!isEditing && (
-        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="flex items-center gap-0.5 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
           <Button
             variant="ghost"
             size="sm"
@@ -481,7 +481,7 @@ export function BranchFromMessageButton({
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 px-2 text-[10px] opacity-0 group-hover:opacity-100 transition-opacity"
+            className="h-6 px-2 text-[10px] md:opacity-0 md:group-hover:opacity-100 transition-opacity"
             onClick={() => onBranch(messageId)}
           >
             <GitBranch className="h-3 w-3 mr-1" />

--- a/components/ui/memory-context-display.tsx
+++ b/components/ui/memory-context-display.tsx
@@ -350,7 +350,7 @@ export function MemoryContextDisplay({
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                        className="h-5 w-5 p-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
                         onClick={() => clearMemoryItem(item.id)}
                       >
                         <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -77,7 +77,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 md:opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 md:group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
     toast-close=""

--- a/components/workspace/chat-panel-v2.tsx
+++ b/components/workspace/chat-panel-v2.tsx
@@ -287,7 +287,7 @@ const ExpandableUserMessage = ({
               </p>
             </div>
           </div>
-          <div className="flex items-center justify-end gap-0.5 mt-1 sm:opacity-0 sm:hover:opacity-100 transition-opacity">
+          <div className="flex items-center justify-end gap-0.5 mt-1 md:opacity-0 md:hover:opacity-100 transition-opacity">
             <Action tooltip="Retry message" onClick={handleIconClick}>
               <RotateCcw className="w-3.5 h-3.5 text-gray-500 hover:text-gray-300" />
             </Action>
@@ -390,7 +390,7 @@ const ExpandableUserMessage = ({
           )}
         </div>
       </div>
-      <div className="flex items-center justify-end gap-0.5 mt-1 opacity-0 hover:opacity-100 transition-opacity">
+      <div className="flex items-center justify-end gap-0.5 mt-1 md:opacity-0 md:hover:opacity-100 transition-opacity">
         <Action tooltip="Retry message" onClick={handleIconClick}>
           <RotateCcw className="w-3.5 h-3.5 text-gray-500 hover:text-gray-300" />
         </Action>
@@ -6238,7 +6238,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                 <div key={file.id} className="flex items-center gap-1.5 bg-gray-800 px-2 py-1 rounded-lg text-xs text-gray-300 group">
                   <FileText className="size-3 text-gray-500" />
                   <span className="truncate max-w-[120px]">{file.name}</span>
-                  <button className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedFiles((prev: AttachedFile[]) => prev.filter((f: AttachedFile) => f.id !== file.id))}>
+                  <button className="md:opacity-0 md:group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedFiles((prev: AttachedFile[]) => prev.filter((f: AttachedFile) => f.id !== file.id))}>
                     <X className="size-3" />
                   </button>
                 </div>
@@ -6255,7 +6255,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                       </button>
                     </>
                   ) : (
-                    <button className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedImages((prev: AttachedImage[]) => prev.filter((i: AttachedImage) => i.id !== img.id))}>
+                    <button className="md:opacity-0 md:group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedImages((prev: AttachedImage[]) => prev.filter((i: AttachedImage) => i.id !== img.id))}>
                       <X className="size-3" />
                     </button>
                   )}
@@ -6265,7 +6265,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                 <div key={file.id} className="flex items-center gap-1.5 bg-gray-800 px-2 py-1 rounded-lg text-xs text-gray-300 group">
                   <FileText className="size-3 text-gray-500" />
                   <span className="truncate max-w-[120px]">{file.name}</span>
-                  <button className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedUploadedFiles((prev: AttachedUploadedFile[]) => prev.filter((f: AttachedUploadedFile) => f.id !== file.id))}>
+                  <button className="md:opacity-0 md:group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedUploadedFiles((prev: AttachedUploadedFile[]) => prev.filter((f: AttachedUploadedFile) => f.id !== file.id))}>
                     <X className="size-3" />
                   </button>
                 </div>
@@ -6275,7 +6275,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                   <LinkIcon className="size-3 text-gray-500" />
                   <span className="truncate max-w-[120px]">{url.title || url.url}</span>
                   {url.isProcessing && <Loader2 className="size-3 animate-spin text-gray-400" />}
-                  <button className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedUrls((prev: AttachedUrl[]) => prev.filter((u: AttachedUrl) => u.id !== url.id))}>
+                  <button className="md:opacity-0 md:group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all" onClick={() => setAttachedUrls((prev: AttachedUrl[]) => prev.filter((u: AttachedUrl) => u.id !== url.id))}>
                     <X className="size-3" />
                   </button>
                 </div>
@@ -6842,7 +6842,7 @@ ${taggedComponent.textContent ? `Text Content: "${taggedComponent.textContent}"`
                                           </div>
                                         ) : (
                                           <button
-                                            className="p-1 text-gray-600 hover:text-red-400 hover:bg-red-500/10 rounded opacity-0 group-hover:opacity-100 transition-all"
+                                            className="p-1 text-gray-600 hover:text-red-400 hover:bg-red-500/10 rounded md:opacity-0 md:group-hover:opacity-100 transition-all"
                                             onClick={() => setMcpDeleteConfirm(key)}
                                             title="Remove server"
                                           >

--- a/components/workspace/code-editor.tsx
+++ b/components/workspace/code-editor.tsx
@@ -1027,7 +1027,7 @@ export function CodeEditor({ file, onSave, projectFiles = [], openFiles = [], on
                   <button
                     onClick={(e) => { e.stopPropagation(); onCloseFile(f) }}
                     className={`size-4 flex items-center justify-center rounded-sm transition-colors ${
-                      isActive ? 'hover:bg-gray-700/60 text-gray-400' : 'opacity-0 group-hover:opacity-100 hover:bg-gray-700/60 text-gray-500'
+                      isActive ? 'hover:bg-gray-700/60 text-gray-400' : 'md:opacity-0 md:group-hover:opacity-100 hover:bg-gray-700/60 text-gray-500'
                     }`}
                   >
                     <X className="size-3" />

--- a/components/workspace/repo-agent-view.tsx
+++ b/components/workspace/repo-agent-view.tsx
@@ -1971,7 +1971,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                     )}
 
                     {/* User Action Buttons */}
-                    <div className="flex justify-end mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="flex justify-end mt-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                       <Actions>
                         <Action tooltip="Retry message" onClick={() => handleRetryMessage(message.id, message.content)}>
                           <ArrowUp className="w-4 h-4" />
@@ -2016,7 +2016,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                     </div>
 
                     {/* Assistant Action Buttons */}
-                    <div className="flex justify-end mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="flex justify-end mt-2 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                       <Actions>
                         <Action tooltip="Copy message" onClick={() => handleCopyMessage(message.content)}>
                           <Copy className="w-4 h-4" />
@@ -2056,7 +2056,7 @@ export function RepoAgentView({ userId }: RepoAgentViewProps) {
                   )}
                   <button
                     onClick={() => removeAttachment(attachment.id)}
-                    className="opacity-0 group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all"
+                    className="md:opacity-0 md:group-hover:opacity-100 hover:text-red-400 text-gray-500 transition-all"
                   >
                     <X className="w-3 h-3" />
                   </button>

--- a/components/workspace/team-activity-feed.tsx
+++ b/components/workspace/team-activity-feed.tsx
@@ -242,7 +242,7 @@ export function TeamActivityFeed({ workspaceId, organizationId }: TeamActivityFe
                       </div>
                     </div>
 
-                    <ChevronRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <ChevronRight className="h-4 w-4 text-muted-foreground md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
On mobile there is no hover, so elements using opacity-0 group-hover:opacity-100 were completely invisible and inaccessible. Changed to md:opacity-0 md:group-hover:opacity-100 so elements are always visible on mobile while preserving hover-to-reveal on desktop.

Fixes across 14 files: message action buttons, attachment delete buttons, project grid actions, chat session controls, branch controls, toast close, storage preview overlays, schema actions, and memory context buttons.

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make hover-revealed controls visible on mobile by gating opacity/hover effects to md and up. Restores access to hidden buttons and overlays on touch devices while keeping hover-to-reveal on desktop.

- **Bug Fixes**
  - Message and chat controls: message action rows, chat session editor/delete, branch buttons, repo agent actions
  - Attachments and files: remove buttons in prompt input and chat panel, code editor tab close, queue item actions
  - Project views: project grid action icons and delete, team activity feed chevron
  - Misc UI: toast close button, storage preview overlays, schema table actions, memory context delete buttons

<sup>Written for commit b6b8a20b74dccbdcff4178f71aaeae12ad1ac390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

