### PR TITLE
Fix docs page: markdown rendering, sidebar nav, mobile UX, and intera…

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 /* Marmelad font applied globally */
 * {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
+    "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-table": "^8.21.3",
     "@types/socket.io": "^3.0.2",
     "@vercel/sdk": "^1.10.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@supabase/supabase-js':
         specifier: latest
         version: 2.89.0
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.12)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -2912,6 +2915,11 @@ packages:
   '@tailwindcss/postcss@4.1.12':
     resolution: {integrity: sha512-5PpLYhCAwf9SJEeIsSmCDLgyVfdBhdBpzX1OJ87anT9IVR0Z9pjM0FNixCAUAHGnMBGB8K99SwAheXrT0Kh6QQ==}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
     engines: {node: '>=12'}
@@ -3803,6 +3811,11 @@ packages:
   crypto-random-string@4.0.0:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   csstype@2.6.21:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
@@ -5991,6 +6004,10 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -10618,6 +10635,11 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.12
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.12)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.12
+
   '@tanstack/react-table@8.21.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@tanstack/table-core': 8.21.3
@@ -11579,6 +11601,8 @@ snapshots:
   crypto-random-string@4.0.0:
     dependencies:
       type-fest: 1.4.0
+
+  cssesc@3.0.0: {}
 
   csstype@2.6.21: {}
 
@@ -14145,6 +14169,11 @@ snapshots:
       points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
 


### PR DESCRIPTION
…ctive features

- Install @tailwindcss/typography plugin to enable prose classes for proper markdown rendering
- Add missing 'Browser Testing' section to sidebar navigation
- Make sidebar nav properly scrollable with overflow-y-auto
- Add mobile bottom navigation bar (Sections, Search, On page, Ask AI)
- Add mobile TOC sheet accessible from bottom nav
- Add "Ask AI about this page" button that opens chatbot with page context
- Fix "Copy page" button to copy full page content as markdown
- Improve mobile layout with responsive padding and bottom-safe area
- Hide floating chat FAB on mobile (replaced by bottom nav)
- Responsive chat widget positioning for mobile

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Markdown rendering and sidebar navigation on the docs page, and adds a mobile bottom nav, on-page TOC, and contextual Ask AI for a better reading experience. Also corrects the "Copy page" action to copy the full page as Markdown.

- **New Features**
  - Prose-styled Markdown rendering via Tailwind Typography.
  - Added "Browser Testing" to the sidebar.
  - Mobile bottom nav with Sections, Search, On page (TOC), and Ask AI.
  - "Ask AI about this page" opens chat prefilled with page context.

- **Bug Fixes**
  - Sidebar navigation now scrolls independently (overflow-y-auto).
  - "Copy page" now copies full content as Markdown.
  - Better mobile spacing and safe-area padding; chat widget positions correctly and FAB is hidden on mobile.

<sup>Written for commit 55ef2fe906a4dc36d55181f1d942685849e39bfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

