### PR TITLE
fix: use site logo (/logo.png) in docs page header instead of styled div

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -689,9 +689,7 @@ export default function DocsPage() {
         {/* Left: Logo + Brand */}
         <div className="flex items-center gap-3 mr-6">
           <Link href="/" className="flex items-center gap-2.5 group">
-            <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600 flex items-center justify-center shadow-lg shadow-orange-500/20">
-              <span className="text-white font-bold text-sm">P</span>
-            </div>
+            <img src="/logo.png" alt="PiPilot" className="w-7 h-7 rounded-lg shadow-lg shadow-orange-500/20" />
             <span className="text-white font-semibold text-sm hidden sm:inline">PiPilot</span>
           </Link>
         </div>


### PR DESCRIPTION
https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the styled “P” box with the real logo (/logo.png) in the docs header to display the correct brand mark and include proper alt text (PiPilot).

<sup>Written for commit bad95680f0a4610bab7502d8503f9728676449ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

