### PR TITLE
Fix activity chat file tools with client-side execution, inline tool …

### DIFF
--- a/components/workspace/workspace-layout.tsx
+++ b/components/workspace/workspace-layout.tsx
@@ -95,7 +95,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
   const [chatPanelVisible, setChatPanelVisible] = useState(true)
 
   // Resizable sidebar width for activity panels
-  const [sidebarWidth, setSidebarWidth] = useState(256)
+  const [sidebarWidth, setSidebarWidth] = useState(360)
   const sidebarResizing = useRef(false)
   const sidebarRef = useRef<HTMLDivElement>(null)
 
@@ -1343,6 +1343,7 @@ export function WorkspaceLayout({ user, projects, newProjectId, initialPrompt }:
                                 projectId={selectedProject?.id || null}
                                 projectFiles={projectFiles}
                                 selectedFile={selectedFile}
+                                openFiles={openFiles}
                                 selectedModel={selectedModel}
                                 onOpenFile={(filePath) => {
                                   const file = projectFiles.find(f => f.path === filePath)


### PR DESCRIPTION
…pills, and open file context

- Wire up client-side tool execution via handleClientFileOperation (matching chat-panel-v2 pattern) so write_file, edit_file, read_file, delete_file, list_files, grep_search all write to IndexedDB
- Add InlineToolPill component with status colors, icons, and clickable file paths
- Add InterleavedContent for position-tracked tool pills inline with message text
- Send currently open files and focused file to API for editor state awareness
- Increase default activity panel width from 256px to 360px (still resizable 200-600px)
- Add openFiles prop to ActivityChatPanel from workspace-layout

https://claude.ai/code/session_01V1zeFeD7XuZKw43mmE99JG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activity Chat file tools now run on the client and persist to IndexedDB, with inline tool pills and editor open-file context for smarter responses. This improves reliability of file operations and makes tool activity visible inline.

- **New Features**
  - Client-side execution for write_file, edit_file, read_file, delete_file, list_files, grep_search via handleClientFileOperation; results persisted to IndexedDB.
  - InlineToolPill and interleaved rendering of tool calls within message text, with status colors/icons and clickable file paths.
  - Open editor tabs and focused file sent to the API; system prompt includes an Editor State section so the assistant can reference the current file.

- **UX Improvements**
  - Increased default activity panel width from 256px to 360px (still resizable 200–600px).

<sup>Written for commit b1accc4fd7b8913736777209bc53be3ff034205c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

